### PR TITLE
Add Additional endpoints to be used in terraform provider from Janitha

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,82 @@
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+
+FROM golang:1
+
+# Avoid warnings by switching to noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
+
+# This Dockerfile adds a non-root user with sudo access. Use the "remoteUser"
+# property in devcontainer.json to use it. On Linux, the container user's GID/UIDs
+# will be updated to match your local UID/GID (when using the dockerFile property).
+# See https://aka.ms/vscode-remote/containers/non-root-user for details.
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+# Configure apt, install packages and tools
+RUN apt-get update \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
+    #
+    # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
+    && apt-get -y install git openssh-client less iproute2 procps lsb-release \
+    #
+    # Install Go tools w/module support
+    && mkdir -p /tmp/gotools \
+    && cd /tmp/gotools \
+    && GO111MODULE=on go get -v golang.org/x/tools/gopls@latest 2>&1 \
+    && GO111MODULE=on go get -v \
+        honnef.co/go/tools/...@latest \
+        golang.org/x/tools/cmd/gorename@latest \
+        golang.org/x/tools/cmd/goimports@latest \
+        golang.org/x/tools/cmd/guru@latest \
+        golang.org/x/lint/golint@latest \
+        github.com/mdempsky/gocode@latest \
+        github.com/cweill/gotests/...@latest \
+        github.com/haya14busa/goplay/cmd/goplay@latest \
+        github.com/sqs/goreturns@latest \
+        github.com/josharian/impl@latest \
+        github.com/davidrjenni/reftools/cmd/fillstruct@latest \
+        github.com/uudashr/gopkgs/v2/cmd/gopkgs@latest  \
+        github.com/ramya-rao-a/go-outline@latest  \
+        github.com/acroca/go-symbols@latest  \
+        github.com/godoctor/godoctor@latest  \
+        github.com/rogpeppe/godef@latest  \
+        github.com/zmb3/gogetdoc@latest \
+        github.com/fatih/gomodifytags@latest  \
+        github.com/mgechev/revive@latest  \
+        github.com/go-delve/delve/cmd/dlv@latest 2>&1 \
+    #
+    # Install Go tools w/o module support
+    && go get -v github.com/alecthomas/gometalinter 2>&1 \
+    #
+    # Install gocode-gomod
+    && go get -x -d github.com/stamblerre/gocode 2>&1 \
+    && go build -o gocode-gomod github.com/stamblerre/gocode \
+    && mv gocode-gomod $GOPATH/bin/ \
+    #
+    # Install golangci-lint
+    && curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin 2>&1 \
+    #
+    # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
+    && groupadd --gid $USER_GID $USERNAME \
+    && useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME \
+    # [Optional] Add sudo support
+    && apt-get install -y sudo \
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
+    && chmod 0440 /etc/sudoers.d/$USERNAME \
+    # Add write permission for /go/pkg
+    && chmod -R a+w /go/pkg \
+    #
+    # Clean up
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/* /go/src /tmp/gotools
+
+# Update this to "on" or "off" as appropriate
+ENV GO111MODULE=auto
+
+# Switch back to dialog for any ad-hoc use of apt-get
+ENV DEBIAN_FRONTEND=dialog

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,27 @@
+// For format details, see https://aka.ms/vscode-remote/devcontainer.json or this file's README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.106.0/containers/go
+{
+	"name": "Go",
+	"dockerFile": "Dockerfile",
+	"runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash",
+		"go.gopath": "/go"
+	},
+	
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"ms-vscode.go"
+	]
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "go version",
+
+	// Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
+	// "remoteUser": "vscode"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@
 *.out
 
 .idea/
+.vscode/settings.json
+.vscode/launch.json

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,9 @@
 lint:
 	go vet
 	test -z $(gofmt -s -l .)
+test:
+	go test -v
+publish: test
+	git tag -fa v0.3.0
+	git push origin --tags
+

--- a/api.go
+++ b/api.go
@@ -578,7 +578,7 @@ func (sc *Client) CreateCustomAlert(corpName, siteName string, body CustomAlertB
 		return CustomAlert{}, err
 	}
 
-	resp, err := sc.doRequest("PATCH", fmt.Sprintf("/v0/corps/%s/sites/%s/alerts", corpName, siteName), string(b))
+	resp, err := sc.doRequest("POST", fmt.Sprintf("/v0/corps/%s/sites/%s/alerts", corpName, siteName), string(b))
 	if err != nil {
 		return CustomAlert{}, err
 	}
@@ -1728,23 +1728,38 @@ func (sc *Client) GetTimeseries(corpName, siteName string, query url.Values) ([]
 	return t.Data, nil
 }
 
-func (sc *Client) CreateSite(corpName, siteName string, body CustomAlertBody) (string, error) {
-	return fmt.Sprintf("Janithet Corp %s, Site %s", corpName, siteName), nil
-	// b, err := json.Marshal(body)
-	// if err != nil {
-	// 	return CustomAlert{}, err
-	// }
+// CreateSiteBody is the structure required to create a Site.
+type CreateSiteBody struct {
+	Name                 string `json:"name"`
+	DisplayName          string `json:"displayName,omitempty"`
+	AgentLevel           string `json:"agentLevel,omitempty"`
+	BlockHTTPCode        int    `json:"blockHTTPCode,omitempty"`
+	BlockDurationSeconds int    `json:"blockDurationSeconds,omitempty"`
+}
 
-	// resp, err := sc.doRequest("PATCH", fmt.Sprintf("/v0/corps/%s/sites/%s/alerts", corpName, siteName), string(b))
-	// if err != nil {
-	// 	return CustomAlert{}, err
-	// }
+// CreateSite Creates a site in a corp.
+func (sc *Client) CreateSite(corpName string, body CreateSiteBody) (Site, error) {
+	b, err := json.Marshal(body)
+	if err != nil {
+		return Site{}, err
+	}
 
-	// var c CustomAlert
-	// err = json.Unmarshal(resp, &c)
-	// if err != nil {
-	// 	return CustomAlert{}, err
-	// }
+	resp, err := sc.doRequest("POST", fmt.Sprintf("/v0/corps/%s/sites", corpName), string(b))
+	if err != nil {
+		return Site{}, err
+	}
 
-	// return c, nil
+	var site Site
+	err = json.Unmarshal(resp, &site)
+	if err != nil {
+		return Site{}, err
+	}
+	return site, nil
+}
+
+// DeleteSite deltes the site
+func (sc *Client) DeleteSite(corpName string, siteName string) error {
+	_, err := sc.doRequest("DELETE", fmt.Sprintf("/v0/corps/%s/sites/%s", corpName, siteName), "")
+
+	return err
 }

--- a/api.go
+++ b/api.go
@@ -1727,3 +1727,24 @@ func (sc *Client) GetTimeseries(corpName, siteName string, query url.Values) ([]
 
 	return t.Data, nil
 }
+
+func (sc *Client) CreateSite(corpName, siteName string, body CustomAlertBody) (string, error) {
+	return fmt.Sprintf("Janithet Corp %s, Site %s", corpName, siteName), nil
+	// b, err := json.Marshal(body)
+	// if err != nil {
+	// 	return CustomAlert{}, err
+	// }
+
+	// resp, err := sc.doRequest("PATCH", fmt.Sprintf("/v0/corps/%s/sites/%s/alerts", corpName, siteName), string(b))
+	// if err != nil {
+	// 	return CustomAlert{}, err
+	// }
+
+	// var c CustomAlert
+	// err = json.Unmarshal(resp, &c)
+	// if err != nil {
+	// 	return CustomAlert{}, err
+	// }
+
+	// return c, nil
+}

--- a/api.go
+++ b/api.go
@@ -1763,3 +1763,65 @@ func (sc *Client) DeleteSite(corpName string, siteName string) error {
 
 	return err
 }
+
+// Conditions contains rule condition
+type Condition struct {
+	Type          string `json:"type"`
+	GroupOperator string `json:"groupOperator"`
+	Field         string `json:"field"`
+	Operator      string `json:"operator"`
+	Value         string `json:"value"`
+}
+
+// Action contains the rule action
+type Action struct {
+	Type string `json:"type"`
+}
+
+// CreateSiteRulesBody contains the rule for the site
+type CreateSiteRulesBody struct {
+	Type          string      `json:"type"`
+	GroupOperator string      `json:"groupOperator"`
+	Enabled       bool        `json:"enabled"`
+	Reason        string      `json:"reason"`
+	Signal        string      `json:"signal"`
+	Expiration    string      `json:"expiration"`
+	Conditions    []Condition `json:"conditions"`
+	Actions       []Action    `json:"actions"`
+}
+
+// ResponseSiteRulesBody contains the response from creating the rule
+type ResponseSiteRulesBody struct {
+	*CreateSiteRulesBody
+	ID        string `json:"id"`
+	CreatedBy string `json:"createdby"`
+	Created   string `json:"created"`
+	Updated   string `json:"updated"`
+}
+
+// type Message struct {
+// 	Message string `json:"message"`
+// }
+// CreateSiteRules creates a rule and returns the response
+func (sc *Client) CreateSiteRules(corpName string, siteName string, body CreateSiteRulesBody) (ResponseSiteRulesBody, error) {
+	b, err := json.Marshal(body)
+	if err != nil {
+		return ResponseSiteRulesBody{}, err
+	}
+	resp, err := sc.doRequest("POST", fmt.Sprintf("/v0/corps/%s/sites/%s/rules", corpName, siteName), string(b))
+	if err != nil {
+		return ResponseSiteRulesBody{}, err
+	}
+	var responseSiteRules ResponseSiteRulesBody
+	err = json.Unmarshal(resp, &responseSiteRules)
+	if err != nil {
+		return ResponseSiteRulesBody{}, err
+	}
+	return responseSiteRules, nil
+}
+
+// DeleteSiteRule deletes a rule and returns an error
+func (sc *Client) DeleteSiteRule(corpName string, siteName string, id string) error {
+	_, err := sc.doRequest("DELETE", fmt.Sprintf("/v0/corps/%s/sites/%s/rules/%s", corpName, siteName, id), "")
+	return err
+}

--- a/api.go
+++ b/api.go
@@ -529,38 +529,8 @@ func (sc *Client) UpdateSite(corpName, siteName string, body UpdateSiteBody) (Si
 	return site, nil
 }
 
-// CustomAlert contains the data for a custom alert
-type CustomAlert struct {
-	*CustomAlertBody
-	ID        string
-	Created   time.Time
-	CreatedBy string
-	Updated   time.Time
-}
-
-// customAlertsResponse is the response for the alerts endpoint
-type customAlertsResponse struct {
-	Data []CustomAlert
-}
-
-// ListCustomAlerts lists custom alerts for a given corp and site.
-func (sc Client) ListCustomAlerts(corpName, siteName string) ([]CustomAlert, error) {
-	resp, err := sc.doRequest("GET", fmt.Sprintf("/v0/corps/%s/sites/%s/alerts", corpName, siteName), "")
-	if err != nil {
-		return []CustomAlert{}, err
-	}
-
-	var car customAlertsResponse
-	err = json.Unmarshal(resp, &car)
-	if err != nil {
-		return []CustomAlert{}, err
-	}
-
-	return car.Data, nil
-}
-
-// CustomAlertBody is the body for creating a custom alert.
-type CustomAlertBody struct {
+// CreateCustomAlertBody is the body for creating a custom alert.
+type CreateCustomAlertBody struct {
 	TagName   string `json:"tagName"`
 	LongName  string `json:"longName"`
 	Interval  int    `json:"interval"`
@@ -569,66 +539,96 @@ type CustomAlertBody struct {
 	Action    string `json:"action"`
 }
 
-// CreateCustomAlert creates a custom alert.
-func (sc Client) CreateCustomAlert(corpName, siteName string, body CustomAlertBody) (CustomAlert, error) {
+//ResponseCustomAlertBody contains the data for a custom alert
+type ResponseCustomAlertBody struct {
+	CreateCustomAlertBody
+	ID        string
+	Created   time.Time
+	CreatedBy string
+	Updated   time.Time
+}
+
+// ResponseCustomAlertsBodyList is the response for the alerts endpoint
+type ResponseCustomAlertsBodyList struct {
+	Data []ResponseCustomAlertBody
+}
+
+// GetAllCustomSiteAlerts lists custom alerts for a given corp and site.
+func (sc Client) GetAllCustomSiteAlerts(corpName, siteName string) (ResponseCustomAlertsBodyList, error) {
+	resp, err := sc.doRequest("GET", fmt.Sprintf("/v0/corps/%s/sites/%s/alerts", corpName, siteName), "")
+	if err != nil {
+		return ResponseCustomAlertsBodyList{}, err
+	}
+
+	var car ResponseCustomAlertsBodyList
+	err = json.Unmarshal(resp, &car)
+	if err != nil {
+		return ResponseCustomAlertsBodyList{}, err
+	}
+
+	return car, nil
+}
+
+// CreateCustomSiteAlert creates a custom alert.
+func (sc Client) CreateCustomSiteAlert(corpName, siteName string, body CreateCustomAlertBody) (ResponseCustomAlertBody, error) {
 	b, err := json.Marshal(body)
 	if err != nil {
-		return CustomAlert{}, err
+		return ResponseCustomAlertBody{}, err
 	}
 
 	resp, err := sc.doRequest("POST", fmt.Sprintf("/v0/corps/%s/sites/%s/alerts", corpName, siteName), string(b))
 	if err != nil {
-		return CustomAlert{}, err
+		return ResponseCustomAlertBody{}, err
 	}
 
-	var c CustomAlert
+	var c ResponseCustomAlertBody
 	err = json.Unmarshal(resp, &c)
 	if err != nil {
-		return CustomAlert{}, err
+		return ResponseCustomAlertBody{}, err
 	}
 
 	return c, nil
 }
 
-// GetCustomAlert gets a custom alert by ID
-func (sc Client) GetCustomAlert(corpName, siteName, id string) (CustomAlert, error) {
+// GetCustomSiteAlertByID gets a custom alert by ID
+func (sc Client) GetCustomSiteAlertByID(corpName, siteName, id string) (ResponseCustomAlertBody, error) {
 	resp, err := sc.doRequest("GET", fmt.Sprintf("/v0/corps/%s/sites/%s/alerts/%s", corpName, siteName, id), "")
 	if err != nil {
-		return CustomAlert{}, err
+		return ResponseCustomAlertBody{}, err
 	}
 
-	var ca CustomAlert
+	var ca ResponseCustomAlertBody
 	err = json.Unmarshal(resp, &ca)
 	if err != nil {
-		return CustomAlert{}, err
+		return ResponseCustomAlertBody{}, err
 	}
 
 	return ca, nil
 }
 
-// UpdateCustomAlert updates a custom alert by id.
-func (sc Client) UpdateCustomAlert(corpName, siteName, id string, body CustomAlertBody) (CustomAlert, error) {
+// UpdateCustomSiteAlertByID updates a custom alert by id.
+func (sc Client) UpdateCustomSiteAlertByID(corpName, siteName, id string, body CreateCustomAlertBody) (ResponseCustomAlertBody, error) {
 	b, err := json.Marshal(body)
 	if err != nil {
-		return CustomAlert{}, logError(1, fmt.Errorf("%s with input %#v", err.Error(), string(b)))
+		return ResponseCustomAlertBody{}, logError(1, fmt.Errorf("%s with input %#v", err.Error(), string(b)))
 	}
 
 	resp, err := sc.doRequest("PATCH", fmt.Sprintf("/v0/corps/%s/sites/%s/alerts/%s", corpName, siteName, id), string(b))
 	if err != nil {
-		return CustomAlert{}, logError(1, fmt.Errorf("%s with input %v", err.Error(), string(b)))
+		return ResponseCustomAlertBody{}, logError(1, fmt.Errorf("%s with input %v", err.Error(), string(b)))
 	}
 
-	var c CustomAlert
+	var c ResponseCustomAlertBody
 	err = json.Unmarshal(resp, &c)
 	if err != nil {
-		return CustomAlert{}, err
+		return ResponseCustomAlertBody{}, err
 	}
 
 	return c, err
 }
 
-// DeleteCustomAlert deletes a custom alert.
-func (sc Client) DeleteCustomAlert(corpName, siteName, id string) error {
+// DeleteCustomSiteAlertByID deletes a custom alert.
+func (sc Client) DeleteCustomSiteAlertByID(corpName, siteName, id string) error {
 	_, err := sc.doRequest("DELETE", fmt.Sprintf("/v0/corps/%s/sites/%s/alerts/%s", corpName, siteName, id), "")
 
 	return err
@@ -2040,6 +2040,15 @@ func getResponseSiteRedactionBody(response []byte) (ResponseSiteRedactionBody, e
 	return responseBody, nil
 }
 
+//GetSiteRedactionByID get a site redaction by id
+func (sc Client) GetSiteRedactionByID(corpName, siteName, id string) (ResponseSiteRedactionBody, error) {
+	resp, err := sc.doRequest("GET", fmt.Sprintf("/v0/corps/%s/sites/%s/redactions/%s", corpName, siteName, id), "")
+	if err != nil {
+		return ResponseSiteRedactionBody{}, err
+	}
+	return getResponseSiteRedactionBody(resp)
+}
+
 // UpdateSiteRedactionByID updates a site redaction and returns a response
 func (sc Client) UpdateSiteRedactionByID(corpName, siteName string, id string, body CreateSiteRedactionBody) (ResponseSiteRedactionBody, error) {
 	b, err := json.Marshal(body)
@@ -2049,15 +2058,6 @@ func (sc Client) UpdateSiteRedactionByID(corpName, siteName string, id string, b
 	resp, err := sc.doRequest("PATCH", fmt.Sprintf("/v0/corps/%s/sites/%s/redactions/%s", corpName, siteName, id), string(b))
 	if err != nil {
 		return ResponseSiteRedactionBody{}, logError(1, fmt.Errorf("%s with input %v", err.Error(), string(b)))
-	}
-	return getResponseSiteRedactionBody(resp)
-}
-
-//GetSiteRedactionByID get a site redaction by id
-func (sc Client) GetSiteRedactionByID(corpName, siteName, id string) (ResponseSiteRedactionBody, error) {
-	resp, err := sc.doRequest("GET", fmt.Sprintf("/v0/corps/%s/sites/%s/redactions/%s", corpName, siteName, id), "")
-	if err != nil {
-		return ResponseSiteRedactionBody{}, err
 	}
 	return getResponseSiteRedactionBody(resp)
 }
@@ -2130,28 +2130,6 @@ func (sc *Client) CreateCorpRule(corpName string, body CreateCorpRuleBody) (Resp
 	return getResponseCorpRuleBody(resp)
 }
 
-// UpdateCorpRuleByID updates a rule and returns a response
-func (sc Client) UpdateCorpRuleByID(corpName, id string, body CreateCorpRuleBody) (ResponseCorpRuleBody, error) {
-	b, err := json.Marshal(body)
-	if err != nil {
-		return ResponseCorpRuleBody{}, logError(1, fmt.Errorf("%s with input %#v", err.Error(), body))
-	}
-	resp, err := sc.doRequest("PUT", fmt.Sprintf("/v0/corps/%s/rules/%s", corpName, id), string(b))
-	if err != nil {
-		return ResponseCorpRuleBody{}, logError(1, fmt.Errorf("%s with input %v", err.Error(), string(b)))
-	}
-	return getResponseCorpRuleBody(resp)
-}
-
-// DeleteCorpRuleByID deletes a rule and returns an error
-func (sc Client) DeleteCorpRuleByID(corpName, id string) error {
-	_, err := sc.doRequest("DELETE", fmt.Sprintf("/v0/corps/%s/rules/%s", corpName, id), "")
-	if err != nil {
-		return logError(1, fmt.Errorf("%s could not delete %s in %s", err.Error(), id, corpName))
-	}
-	return nil
-}
-
 //GetCorpRuleByID get a site rule by id
 func (sc Client) GetCorpRuleByID(corpName, id string) (ResponseCorpRuleBody, error) {
 	resp, err := sc.doRequest("GET", fmt.Sprintf("/v0/corps/%s/rules/%s", corpName, id), "")
@@ -2174,6 +2152,29 @@ func (sc Client) GetAllCorpRules(corpName string) (ResponseCorpRuleBodyList, err
 	}
 	return responseRuleBodyList, nil
 }
+
+// UpdateCorpRuleByID updates a rule and returns a response
+func (sc Client) UpdateCorpRuleByID(corpName, id string, body CreateCorpRuleBody) (ResponseCorpRuleBody, error) {
+	b, err := json.Marshal(body)
+	if err != nil {
+		return ResponseCorpRuleBody{}, logError(1, fmt.Errorf("%s with input %#v", err.Error(), body))
+	}
+	resp, err := sc.doRequest("PUT", fmt.Sprintf("/v0/corps/%s/rules/%s", corpName, id), string(b))
+	if err != nil {
+		return ResponseCorpRuleBody{}, logError(1, fmt.Errorf("%s with input %v", err.Error(), string(b)))
+	}
+	return getResponseCorpRuleBody(resp)
+}
+
+// DeleteCorpRuleByID deletes a rule and returns an error
+func (sc Client) DeleteCorpRuleByID(corpName, id string) error {
+	_, err := sc.doRequest("DELETE", fmt.Sprintf("/v0/corps/%s/rules/%s", corpName, id), "")
+	if err != nil {
+		return logError(1, fmt.Errorf("%s could not delete %s in %s", err.Error(), id, corpName))
+	}
+	return nil
+}
+
 func getResponseCorpRuleBody(response []byte) (ResponseCorpRuleBody, error) {
 	var responseCorpRule ResponseCorpRuleBody
 	err := json.Unmarshal(response, &responseCorpRule)
@@ -2194,28 +2195,6 @@ func (sc Client) CreateCorpList(corpName string, body CreateListBody) (ResponseL
 		return ResponseListBody{}, logError(1, fmt.Errorf("%s with input %v", err.Error(), string(b)))
 	}
 	return getResponseListBody(resp)
-}
-
-// UpdateCorpListByID updates a corp list
-func (sc Client) UpdateCorpListByID(corpName string, id string, body UpdateListBody) (ResponseListBody, error) {
-	b, err := json.Marshal(body)
-	if err != nil {
-		return ResponseListBody{}, logError(1, fmt.Errorf("%s with input %#v", err.Error(), body))
-	}
-	resp, err := sc.doRequest("PATCH", fmt.Sprintf("/v0/corps/%s/lists/%s", corpName, id), string(b))
-	if err != nil {
-		return ResponseListBody{}, logError(1, fmt.Errorf("%s with input %v", err.Error(), string(b)))
-	}
-	return getResponseListBody(resp)
-}
-
-// DeleteCorpListByID deletes a rule and returns an error
-func (sc Client) DeleteCorpListByID(corpName string, id string) error {
-	_, err := sc.doRequest("DELETE", fmt.Sprintf("/v0/corps/%s/lists/%s", corpName, id), "")
-	if err != nil {
-		return logError(1, fmt.Errorf("%s could not delete %s in %s", err.Error(), id, corpName))
-	}
-	return nil
 }
 
 // GetCorpListByID get corp list by ID
@@ -2240,8 +2219,183 @@ func (sc Client) GetAllCorpLists(corpName string) (ResponseListBodyList, error) 
 	}
 	return responseListBodyList, nil
 }
+
+// UpdateCorpListByID updates a corp list
+func (sc Client) UpdateCorpListByID(corpName string, id string, body UpdateListBody) (ResponseListBody, error) {
+	b, err := json.Marshal(body)
+	if err != nil {
+		return ResponseListBody{}, logError(1, fmt.Errorf("%s with input %#v", err.Error(), body))
+	}
+	resp, err := sc.doRequest("PATCH", fmt.Sprintf("/v0/corps/%s/lists/%s", corpName, id), string(b))
+	if err != nil {
+		return ResponseListBody{}, logError(1, fmt.Errorf("%s with input %v", err.Error(), string(b)))
+	}
+	return getResponseListBody(resp)
+}
+
+// DeleteCorpListByID deletes a rule and returns an error
+func (sc Client) DeleteCorpListByID(corpName string, id string) error {
+	_, err := sc.doRequest("DELETE", fmt.Sprintf("/v0/corps/%s/lists/%s", corpName, id), "")
+	if err != nil {
+		return logError(1, fmt.Errorf("%s could not delete %s in %s", err.Error(), id, corpName))
+	}
+	return nil
+}
+
 func logError(skip int, err error) error {
 	pc, _, line, _ := runtime.Caller(skip)
 	fn := runtime.FuncForPC(pc).Name()
 	return fmt.Errorf("[ERROR] %s:%d\t%s", fn, line, err.Error())
+}
+
+//CreateSignalTagBody create a signal tag
+type CreateSignalTagBody struct {
+	ShortName   string `json:"shortName,omitempty"`   //The display name of the signal tag
+	Description string `json:"description,omitempty"` //Optional signal tag description
+}
+
+//UpdateSignalTagBody update a signal tag
+type UpdateSignalTagBody struct {
+	Description string `json:"description,omitempty"` //Optional signal tag description
+}
+
+//ResponseSignalTagBody response singnal tag
+type ResponseSignalTagBody struct {
+	CreateSignalTagBody
+	TagName       string    `json:"tagName",omitempty"`  //The identifier for the signal tag
+	LongName      string    `json:"longName",omitempty"` //The display name of the signal tag - deprecated
+	Configurable  bool      `json:"configurable",omitempty"`
+	Informational bool      `json:"informational",omitempty"`
+	NeedsResponse bool      `json:"needsResponse",omitempty"`
+	CreatedBy     string    `json:"createdBy",omitempty"` //Email address of the user that created the resource
+	Created       time.Time `json:"created",omitempty"`   //Created RFC3339 date time
+}
+
+//ResponseSingnalTagBodyList response list
+type ResponseSingnalTagBodyList struct {
+	Data []ResponseSignalTagBody `json:"data"` //ResponseSignalTagBody
+}
+
+//CreateCorpSignalTag create signal tag
+func (sc Client) CreateCorpSignalTag(corpName string, body CreateSignalTagBody) (ResponseSignalTagBody, error) {
+	b, err := json.Marshal(body)
+	if err != nil {
+		return ResponseSignalTagBody{}, logError(1, fmt.Errorf("%s with input %#v", err.Error(), body))
+	}
+	resp, err := sc.doRequest("POST", fmt.Sprintf("/v0/corps/%s/tags", corpName), string(b))
+	if err != nil {
+		return ResponseSignalTagBody{}, logError(1, fmt.Errorf("%s with input %v", err.Error(), string(b)))
+	}
+	return getResponseSignalTagBody(resp)
+}
+
+//GetCorpSignalTagByID get corp signal by id
+func (sc Client) GetCorpSignalTagByID(corpName string, id string) (ResponseSignalTagBody, error) {
+	resp, err := sc.doRequest("GET", fmt.Sprintf("/v0/corps/%s/tags/%s", corpName, id), "")
+	if err != nil {
+		return ResponseSignalTagBody{}, err
+	}
+	return getResponseSignalTagBody(resp)
+}
+
+//GetAllCorpSignalTags get all corp signals
+func (sc Client) GetAllCorpSignalTags(corpName string) (ResponseSingnalTagBodyList, error) {
+	resp, err := sc.doRequest("GET", fmt.Sprintf("/v0/corps/%s/tags", corpName), "")
+	if err != nil {
+		return ResponseSingnalTagBodyList{}, logError(1, fmt.Errorf("%s", err.Error()))
+	}
+	var responseSignalTagBodyList ResponseSingnalTagBodyList
+	err = json.Unmarshal(resp, &responseSignalTagBodyList)
+	if err != nil {
+		return ResponseSingnalTagBodyList{}, err
+	}
+	return responseSignalTagBodyList, nil
+}
+
+//UpdateCorpSignalTagByID update corp signal
+func (sc Client) UpdateCorpSignalTagByID(corpName string, id string, body UpdateSignalTagBody) (ResponseSignalTagBody, error) {
+	b, err := json.Marshal(body)
+	if err != nil {
+		return ResponseSignalTagBody{}, logError(1, fmt.Errorf("%s with input %#v", err.Error(), body))
+	}
+	resp, err := sc.doRequest("PATCH", fmt.Sprintf("/v0/corps/%s/tags/%s", corpName, id), string(b))
+	if err != nil {
+		return ResponseSignalTagBody{}, logError(1, fmt.Errorf("%s with input %v", err.Error(), string(b)))
+	}
+	return getResponseSignalTagBody(resp)
+}
+
+//DeleteCorpSignalTagByID delete signal tag by id
+func (sc Client) DeleteCorpSignalTagByID(corpName string, id string) error {
+	_, err := sc.doRequest("DELETE", fmt.Sprintf("/v0/corps/%s/tags/%s", corpName, id), "")
+	if err != nil {
+		return logError(1, fmt.Errorf("%s could not delete %s in %s", err.Error(), id, corpName))
+	}
+	return nil
+}
+func getResponseSignalTagBody(response []byte) (ResponseSignalTagBody, error) {
+	var responseBody ResponseSignalTagBody
+	err := json.Unmarshal(response, &responseBody)
+	if err != nil {
+		return ResponseSignalTagBody{}, err
+	}
+	return responseBody, nil
+}
+
+//CreateSiteSignalTag create signal tag
+func (sc Client) CreateSiteSignalTag(corpName, siteName string, body CreateSignalTagBody) (ResponseSignalTagBody, error) {
+	b, err := json.Marshal(body)
+	if err != nil {
+		return ResponseSignalTagBody{}, logError(1, fmt.Errorf("%s with input %#v", err.Error(), body))
+	}
+	resp, err := sc.doRequest("POST", fmt.Sprintf("/v0/corps/%s/sites/%s/tags", corpName, siteName), string(b))
+	if err != nil {
+		return ResponseSignalTagBody{}, logError(1, fmt.Errorf("%s with input %v", err.Error(), string(b)))
+	}
+	return getResponseSignalTagBody(resp)
+}
+
+//GetSiteSignalTagByID get site signal by id
+func (sc Client) GetSiteSignalTagByID(corpName, siteName, id string) (ResponseSignalTagBody, error) {
+	resp, err := sc.doRequest("GET", fmt.Sprintf("/v0/corps/%s/sites/%s/tags/%s", corpName, siteName, id), "")
+	if err != nil {
+		return ResponseSignalTagBody{}, err
+	}
+	return getResponseSignalTagBody(resp)
+}
+
+//GetAllSiteSignalTags get all site signals
+func (sc Client) GetAllSiteSignalTags(corpName, siteName string) (ResponseSingnalTagBodyList, error) {
+	resp, err := sc.doRequest("GET", fmt.Sprintf("/v0/corps/%s/sites/%s/tags", corpName, siteName), "")
+	if err != nil {
+		return ResponseSingnalTagBodyList{}, logError(1, fmt.Errorf("%s", err.Error()))
+	}
+	var responseSignalTagBodyList ResponseSingnalTagBodyList
+	err = json.Unmarshal(resp, &responseSignalTagBodyList)
+	if err != nil {
+		return ResponseSingnalTagBodyList{}, err
+	}
+	return responseSignalTagBodyList, nil
+}
+
+//UpdateSiteSignalTagByID update site signal
+func (sc Client) UpdateSiteSignalTagByID(corpName, siteName, id string, body UpdateSignalTagBody) (ResponseSignalTagBody, error) {
+	b, err := json.Marshal(body)
+	if err != nil {
+		return ResponseSignalTagBody{}, logError(1, fmt.Errorf("%s with input %#v", err.Error(), body))
+	}
+	resp, err := sc.doRequest("PATCH", fmt.Sprintf("/v0/corps/%s/sites/%s/tags/%s", corpName, siteName, id), string(b))
+	if err != nil {
+		return ResponseSignalTagBody{}, logError(1, fmt.Errorf("%s with input %v", err.Error(), string(b)))
+	}
+	return getResponseSignalTagBody(resp)
+}
+
+//DeleteSiteSignalTagByID delete signal tag by id
+func (sc Client) DeleteSiteSignalTagByID(corpName, siteName, id string) error {
+	_, err := sc.doRequest("DELETE", fmt.Sprintf("/v0/corps/%s/sites/%s/tags/%s", corpName, siteName, id), "")
+	if err != nil {
+		return logError(1, fmt.Errorf("%s could not delete %s in %s in %s", err.Error(), id, corpName, siteName))
+	}
+	return nil
 }

--- a/api.go
+++ b/api.go
@@ -1794,7 +1794,7 @@ type CreateSiteRuleBody struct {
 
 // ResponseSiteRuleBody contains the response from creating the rule
 type ResponseSiteRuleBody struct {
-	*CreateSiteRuleBody
+	CreateSiteRuleBody
 	ID        string    `json:"id"`        //internal ID
 	CreatedBy string    `json:"createdby"` //Email address of the user that created the item
 	Created   time.Time `json:"created"`   //Created RFC3339 date time
@@ -1899,7 +1899,7 @@ type Entries struct {
 
 // ResponseListBody contains the response from creating the list
 type ResponseListBody struct {
-	*CreateListBody
+	CreateListBody
 	ID        string    `json:"id"`        //internal ID
 	CreatedBy string    `json:"createdby"` //Email address of the user that created the item
 	Created   time.Time `json:"created"`   //Created RFC3339 date time
@@ -1990,7 +1990,7 @@ type CreateSiteRedactionBody struct {
 
 // ResponseSiteRedactionBody redaction response
 type ResponseSiteRedactionBody struct {
-	*CreateSiteRedactionBody
+	CreateSiteRedactionBody
 	ID        string    `json:"id"`        //internal ID
 	CreatedBy string    `json:"createdby"` //Email address of the user that created the item
 	Created   time.Time `json:"created"`   //Created RFC3339 date time
@@ -2104,7 +2104,7 @@ type CreateCorpRuleBody struct {
 
 // ResponseCorpRuleBody contains the response from creating the rule
 type ResponseCorpRuleBody struct {
-	*CreateCorpRuleBody
+	CreateCorpRuleBody
 	ID        string    `json:"id"`
 	CreatedBy string    `json:"createdby"` //Email address of the user that created the item
 	Created   time.Time `json:"created"`   //Created RFC3339 date time

--- a/api.go
+++ b/api.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"runtime"
 	"strings"
 	"time"
 )
@@ -609,12 +610,12 @@ func (sc Client) GetCustomAlert(corpName, siteName, id string) (CustomAlert, err
 func (sc Client) UpdateCustomAlert(corpName, siteName, id string, body CustomAlertBody) (CustomAlert, error) {
 	b, err := json.Marshal(body)
 	if err != nil {
-		return CustomAlert{}, fmt.Errorf("%s with input %#v", err.Error(), string(b))
+		return CustomAlert{}, logError(1, fmt.Errorf("%s with input %#v", err.Error(), string(b)))
 	}
 
 	resp, err := sc.doRequest("PATCH", fmt.Sprintf("/v0/corps/%s/sites/%s/alerts/%s", corpName, siteName, id), string(b))
 	if err != nil {
-		return CustomAlert{}, fmt.Errorf("%s with input %v", err.Error(), string(b))
+		return CustomAlert{}, logError(1, fmt.Errorf("%s with input %v", err.Error(), string(b)))
 	}
 
 	var c CustomAlert
@@ -1738,18 +1739,18 @@ type CreateSiteBody struct {
 func (sc Client) CreateSite(corpName string, body CreateSiteBody) (Site, error) {
 	b, err := json.Marshal(body)
 	if err != nil {
-		return Site{}, fmt.Errorf("%s with input %#v", err.Error(), body)
+		return Site{}, logError(1, fmt.Errorf("%s with input %#v", err.Error(), body))
 	}
 
 	resp, err := sc.doRequest("POST", fmt.Sprintf("/v0/corps/%s/sites", corpName), string(b))
 	if err != nil {
-		return Site{}, fmt.Errorf("%s with input %v", err.Error(), string(b))
+		return Site{}, logError(1, fmt.Errorf("%s with input %v", err.Error(), string(b)))
 	}
 
 	var site Site
 	err = json.Unmarshal(resp, &site)
 	if err != nil {
-		return Site{}, fmt.Errorf("%s with input %v", err.Error(), resp)
+		return Site{}, logError(1, fmt.Errorf("%s with input %v", err.Error(), resp))
 	}
 	return site, nil
 }
@@ -1759,7 +1760,7 @@ func (sc Client) DeleteSite(corpName, siteName string) error {
 	_, err := sc.doRequest("DELETE", fmt.Sprintf("/v0/corps/%s/sites/%s", corpName, siteName), "")
 
 	if err != nil {
-		return fmt.Errorf("%s could not delete %s in %s ", err.Error(), corpName, siteName)
+		return logError(1, fmt.Errorf("%s could not delete %s in %s ", err.Error(), corpName, siteName))
 	}
 	return nil
 }
@@ -1810,11 +1811,11 @@ type ResponseSiteRuleListData struct {
 func (sc *Client) CreateSiteRule(corpName, siteName string, body CreateSiteRuleBody) (ResponseSiteRuleBody, error) {
 	b, err := json.Marshal(body)
 	if err != nil {
-		return ResponseSiteRuleBody{}, fmt.Errorf("%s with input %#v", err.Error(), body)
+		return ResponseSiteRuleBody{}, logError(1, fmt.Errorf("%s with input %#v", err.Error(), body))
 	}
 	resp, err := sc.doRequest("POST", fmt.Sprintf("/v0/corps/%s/sites/%s/rules", corpName, siteName), string(b))
 	if err != nil {
-		return ResponseSiteRuleBody{}, fmt.Errorf("%s with input %v", err.Error(), string(b))
+		return ResponseSiteRuleBody{}, logError(1, fmt.Errorf("%s with input %v", err.Error(), string(b)))
 	}
 	return getResponseSiteRuleBody(resp)
 }
@@ -1823,11 +1824,11 @@ func (sc *Client) CreateSiteRule(corpName, siteName string, body CreateSiteRuleB
 func (sc Client) UpdateSiteRuleByID(corpName, siteName, id string, body CreateSiteRuleBody) (ResponseSiteRuleBody, error) {
 	b, err := json.Marshal(body)
 	if err != nil {
-		return ResponseSiteRuleBody{}, fmt.Errorf("%s with input %#v", err.Error(), body)
+		return ResponseSiteRuleBody{}, logError(1, fmt.Errorf("%s with input %#v", err.Error(), body))
 	}
 	resp, err := sc.doRequest("PUT", fmt.Sprintf("/v0/corps/%s/sites/%s/rules/%s", corpName, siteName, id), string(b))
 	if err != nil {
-		return ResponseSiteRuleBody{}, fmt.Errorf("%s with input %v", err.Error(), string(b))
+		return ResponseSiteRuleBody{}, logError(1, fmt.Errorf("%s with input %v", err.Error(), string(b)))
 	}
 	return getResponseSiteRuleBody(resp)
 }
@@ -1836,7 +1837,7 @@ func (sc Client) UpdateSiteRuleByID(corpName, siteName, id string, body CreateSi
 func (sc Client) DeleteSiteRuleByID(corpName, siteName, id string) error {
 	_, err := sc.doRequest("DELETE", fmt.Sprintf("/v0/corps/%s/sites/%s/rules/%s", corpName, siteName, id), "")
 	if err != nil {
-		return fmt.Errorf("%s could not delete %s in %s in %s", err.Error(), id, corpName, siteName)
+		return logError(1, fmt.Errorf("%s could not delete %s in %s in %s", err.Error(), id, corpName, siteName))
 	}
 	return nil
 }
@@ -1845,7 +1846,7 @@ func (sc Client) DeleteSiteRuleByID(corpName, siteName, id string) error {
 func (sc Client) GetSiteRuleByID(corpName, siteName, id string) (ResponseSiteRuleBody, error) {
 	resp, err := sc.doRequest("GET", fmt.Sprintf("/v0/corps/%s/sites/%s/rules/%s", corpName, siteName, id), "")
 	if err != nil {
-		return ResponseSiteRuleBody{}, fmt.Errorf("%s could not get %s in %s in %s", err.Error(), id, siteName, corpName)
+		return ResponseSiteRuleBody{}, logError(1, fmt.Errorf("%s could not get %s in %s in %s", err.Error(), id, siteName, corpName))
 	}
 	return getResponseSiteRuleBody(resp)
 }
@@ -1854,7 +1855,7 @@ func getResponseSiteRuleBody(response []byte) (ResponseSiteRuleBody, error) {
 	var responseSiteRules ResponseSiteRuleBody
 	err := json.Unmarshal(response, &responseSiteRules)
 	if err != nil {
-		return ResponseSiteRuleBody{}, fmt.Errorf("%s with input %v", err.Error(), response)
+		return ResponseSiteRuleBody{}, logError(1, fmt.Errorf("%s with input %v", err.Error(), response))
 	}
 	return responseSiteRules, nil
 }
@@ -1916,11 +1917,11 @@ type ResponseListListData struct {
 func (sc Client) CreateSiteList(corpName, siteName string, body CreateListBody) (ResponseListBody, error) {
 	b, err := json.Marshal(body)
 	if err != nil {
-		return ResponseListBody{}, fmt.Errorf("%s with input %#v", err.Error(), body)
+		return ResponseListBody{}, logError(1, fmt.Errorf("%s with input %#v", err.Error(), body))
 	}
 	resp, err := sc.doRequest("POST", fmt.Sprintf("/v0/corps/%s/sites/%s/lists", corpName, siteName), string(b))
 	if err != nil {
-		return ResponseListBody{}, fmt.Errorf("%s with input %v", err.Error(), string(b))
+		return ResponseListBody{}, logError(1, fmt.Errorf("%s with input %v", err.Error(), string(b)))
 	}
 	return getResponseListBody(resp)
 }
@@ -1938,11 +1939,11 @@ func getResponseListBody(response []byte) (ResponseListBody, error) {
 func (sc Client) UpdateSiteListByID(corpName, siteName string, id string, body UpdateListBody) (ResponseListBody, error) {
 	b, err := json.Marshal(body)
 	if err != nil {
-		return ResponseListBody{}, fmt.Errorf("%s with input %#v", err.Error(), body)
+		return ResponseListBody{}, logError(1, fmt.Errorf("%s with input %#v", err.Error(), body))
 	}
 	resp, err := sc.doRequest("PATCH", fmt.Sprintf("/v0/corps/%s/sites/%s/lists/%s", corpName, siteName, id), string(b))
 	if err != nil {
-		return ResponseListBody{}, fmt.Errorf("%s with input %v", err.Error(), string(b))
+		return ResponseListBody{}, logError(1, fmt.Errorf("%s with input %v", err.Error(), string(b)))
 	}
 	return getResponseListBody(resp)
 }
@@ -1951,7 +1952,7 @@ func (sc Client) UpdateSiteListByID(corpName, siteName string, id string, body U
 func (sc Client) DeleteSiteListByID(corpName, siteName string, id string) error {
 	_, err := sc.doRequest("DELETE", fmt.Sprintf("/v0/corps/%s/sites/%s/lists/%s", corpName, siteName, id), "")
 	if err != nil {
-		return fmt.Errorf("%s could not delete %s in %s in %s", err.Error(), id, corpName, siteName)
+		return logError(1, fmt.Errorf("%s could not delete %s in %s in %s", err.Error(), id, corpName, siteName))
 	}
 	return nil
 }
@@ -1993,11 +1994,11 @@ type ResponseSiteRedactionBodyList struct {
 func (sc Client) CreateSiteRedaction(corpName, siteName string, body CreateSiteRedactionBody) (ResponseSiteRedactionBody, error) {
 	b, err := json.Marshal(body)
 	if err != nil {
-		return ResponseSiteRedactionBody{}, fmt.Errorf("%s with input %#v", err.Error(), body)
+		return ResponseSiteRedactionBody{}, logError(1, fmt.Errorf("%s with input %#v", err.Error(), body))
 	}
 	resp, err := sc.doRequest("POST", fmt.Sprintf("/v0/corps/%s/sites/%s/redactions", corpName, siteName), string(b))
 	if err != nil {
-		return ResponseSiteRedactionBody{}, fmt.Errorf("%s with input %v", err.Error(), string(b))
+		return ResponseSiteRedactionBody{}, logError(1, fmt.Errorf("%s with input %v", err.Error(), string(b)))
 	}
 	redactionsData, err := getResponseSiteRedactionListBody(resp)
 
@@ -2030,11 +2031,11 @@ func getResponseSiteRedactionBody(response []byte) (ResponseSiteRedactionBody, e
 func (sc Client) UpdateSiteRedactionByID(corpName, siteName string, id string, body CreateSiteRedactionBody) (ResponseSiteRedactionBody, error) {
 	b, err := json.Marshal(body)
 	if err != nil {
-		return ResponseSiteRedactionBody{}, fmt.Errorf("%s with input %#v", err.Error(), body)
+		return ResponseSiteRedactionBody{}, logError(1, fmt.Errorf("%s with input %#v", err.Error(), body))
 	}
 	resp, err := sc.doRequest("PATCH", fmt.Sprintf("/v0/corps/%s/sites/%s/redactions/%s", corpName, siteName, id), string(b))
 	if err != nil {
-		return ResponseSiteRedactionBody{}, fmt.Errorf("%s with input %v", err.Error(), string(b))
+		return ResponseSiteRedactionBody{}, logError(1, fmt.Errorf("%s with input %v", err.Error(), string(b)))
 	}
 	return getResponseSiteRedactionBody(resp)
 }
@@ -2052,7 +2053,7 @@ func (sc Client) GetSiteRedactionByID(corpName, siteName, id string) (ResponseSi
 func (sc Client) DeleteSiteRedactionByID(corpName, siteName string, id string) error {
 	_, err := sc.doRequest("DELETE", fmt.Sprintf("/v0/corps/%s/sites/%s/redactions/%s", corpName, siteName, id), "")
 	if err != nil {
-		return fmt.Errorf("%s could not delete %s in %s in %s", err.Error(), id, corpName, siteName)
+		return logError(1, fmt.Errorf("%s could not delete %s in %s in %s", err.Error(), id, corpName, siteName))
 	}
 	return nil
 }
@@ -2101,11 +2102,11 @@ type ResponseCorpRuleBody struct {
 func (sc *Client) CreateCorpRule(corpName string, body CreateCorpRuleBody) (ResponseCorpRuleBody, error) {
 	b, err := json.Marshal(body)
 	if err != nil {
-		return ResponseCorpRuleBody{}, fmt.Errorf("%s with input %#v", err.Error(), body)
+		return ResponseCorpRuleBody{}, logError(1, fmt.Errorf("%s with input %#v", err.Error(), body))
 	}
 	resp, err := sc.doRequest("POST", fmt.Sprintf("/v0/corps/%s/rules", corpName), string(b))
 	if err != nil {
-		return ResponseCorpRuleBody{}, fmt.Errorf("%s with input %v", err.Error(), string(b))
+		return ResponseCorpRuleBody{}, logError(1, fmt.Errorf("%s with input %v", err.Error(), string(b)))
 	}
 	return getResponseCorpRuleBody(resp)
 }
@@ -2114,11 +2115,11 @@ func (sc *Client) CreateCorpRule(corpName string, body CreateCorpRuleBody) (Resp
 func (sc Client) UpdateCorpRuleByID(corpName, id string, body CreateCorpRuleBody) (ResponseCorpRuleBody, error) {
 	b, err := json.Marshal(body)
 	if err != nil {
-		return ResponseCorpRuleBody{}, fmt.Errorf("%s with input %#v", err.Error(), body)
+		return ResponseCorpRuleBody{}, logError(1, fmt.Errorf("%s with input %#v", err.Error(), body))
 	}
 	resp, err := sc.doRequest("PUT", fmt.Sprintf("/v0/corps/%s/rules/%s", corpName, id), string(b))
 	if err != nil {
-		return ResponseCorpRuleBody{}, fmt.Errorf("%s with input %v", err.Error(), string(b))
+		return ResponseCorpRuleBody{}, logError(1, fmt.Errorf("%s with input %v", err.Error(), string(b)))
 	}
 	return getResponseCorpRuleBody(resp)
 }
@@ -2127,7 +2128,7 @@ func (sc Client) UpdateCorpRuleByID(corpName, id string, body CreateCorpRuleBody
 func (sc Client) DeleteCorpRuleByID(corpName, id string) error {
 	_, err := sc.doRequest("DELETE", fmt.Sprintf("/v0/corps/%s/rules/%s", corpName, id), "")
 	if err != nil {
-		return fmt.Errorf("%s could not delete %s in %s", err.Error(), id, corpName)
+		return logError(1, fmt.Errorf("%s could not delete %s in %s", err.Error(), id, corpName))
 	}
 	return nil
 }
@@ -2136,7 +2137,7 @@ func (sc Client) DeleteCorpRuleByID(corpName, id string) error {
 func (sc Client) GetCorpRuleByID(corpName, id string) (ResponseCorpRuleBody, error) {
 	resp, err := sc.doRequest("GET", fmt.Sprintf("/v0/corps/%s/rules/%s", corpName, id), "")
 	if err != nil {
-		return ResponseCorpRuleBody{}, fmt.Errorf("%s could not get %s in %s", err.Error(), id, corpName)
+		return ResponseCorpRuleBody{}, logError(1, fmt.Errorf("%s could not get %s in %s", err.Error(), id, corpName))
 	}
 	return getResponseCorpRuleBody(resp)
 }
@@ -2145,7 +2146,7 @@ func getResponseCorpRuleBody(response []byte) (ResponseCorpRuleBody, error) {
 	var responseCorpRule ResponseCorpRuleBody
 	err := json.Unmarshal(response, &responseCorpRule)
 	if err != nil {
-		return ResponseCorpRuleBody{}, fmt.Errorf("%s with input %v", err.Error(), response)
+		return ResponseCorpRuleBody{}, logError(1, fmt.Errorf("%s with input %v", err.Error(), response))
 	}
 	return responseCorpRule, nil
 }
@@ -2154,11 +2155,11 @@ func getResponseCorpRuleBody(response []byte) (ResponseCorpRuleBody, error) {
 func (sc Client) CreateCorpList(corpName string, body CreateListBody) (ResponseListBody, error) {
 	b, err := json.Marshal(body)
 	if err != nil {
-		return ResponseListBody{}, fmt.Errorf("%s with input %#v", err.Error(), body)
+		return ResponseListBody{}, logError(1, fmt.Errorf("%s with input %#v", err.Error(), body))
 	}
 	resp, err := sc.doRequest("POST", fmt.Sprintf("/v0/corps/%s/lists", corpName), string(b))
 	if err != nil {
-		return ResponseListBody{}, fmt.Errorf("%s with input %v", err.Error(), string(b))
+		return ResponseListBody{}, logError(1, fmt.Errorf("%s with input %v", err.Error(), string(b)))
 	}
 	return getResponseListBody(resp)
 }
@@ -2167,11 +2168,11 @@ func (sc Client) CreateCorpList(corpName string, body CreateListBody) (ResponseL
 func (sc Client) UpdateCorpListByID(corpName string, id string, body UpdateListBody) (ResponseListBody, error) {
 	b, err := json.Marshal(body)
 	if err != nil {
-		return ResponseListBody{}, fmt.Errorf("%s with input %#v", err.Error(), body)
+		return ResponseListBody{}, logError(1, fmt.Errorf("%s with input %#v", err.Error(), body))
 	}
 	resp, err := sc.doRequest("PATCH", fmt.Sprintf("/v0/corps/%s/lists/%s", corpName, id), string(b))
 	if err != nil {
-		return ResponseListBody{}, fmt.Errorf("%s with input %v", err.Error(), string(b))
+		return ResponseListBody{}, logError(1, fmt.Errorf("%s with input %v", err.Error(), string(b)))
 	}
 	return getResponseListBody(resp)
 }
@@ -2180,7 +2181,7 @@ func (sc Client) UpdateCorpListByID(corpName string, id string, body UpdateListB
 func (sc Client) DeleteCorpListByID(corpName string, id string) error {
 	_, err := sc.doRequest("DELETE", fmt.Sprintf("/v0/corps/%s/lists/%s", corpName, id), "")
 	if err != nil {
-		return fmt.Errorf("%s could not delete %s in %s", err.Error(), id, corpName)
+		return logError(1, fmt.Errorf("%s could not delete %s in %s", err.Error(), id, corpName))
 	}
 	return nil
 }
@@ -2192,4 +2193,9 @@ func (sc Client) GetCorpListByID(corpName string, id string) (ResponseListBody, 
 		return ResponseListBody{}, err
 	}
 	return getResponseListBody(resp)
+}
+func logError(skip int, err error) error {
+	pc, _, line, _ := runtime.Caller(skip)
+	fn := runtime.FuncForPC(pc).Name()
+	return fmt.Errorf("[ERROR] %s:%d\t%s", fn, line, err.Error())
 }

--- a/api.go
+++ b/api.go
@@ -561,7 +561,7 @@ type ResponseCustomAlertsBodyList struct {
 func (sc Client) GetAllSiteCustomAlerts(corpName, siteName string) (ResponseCustomAlertsBodyList, error) {
 	resp, err := sc.doRequest("GET", fmt.Sprintf("/v0/corps/%s/sites/%s/alerts", corpName, siteName), "")
 	if err != nil {
-		return ResponseCustomAlertsBodyList{}, err
+		return ResponseCustomAlertsBodyList{}, logError(1, fmt.Errorf("%s with %s %s ", err.Error(), corpName, siteName))
 	}
 
 	var car ResponseCustomAlertsBodyList
@@ -1868,7 +1868,7 @@ func (sc *Client) GetAllSiteRules(corpName, siteName string) (ResponseSiteRuleBo
 	resp, err := sc.doRequest("GET", fmt.Sprintf("/v0/corps/%s/sites/%s/rules", corpName, siteName), "")
 
 	if err != nil {
-		return ResponseSiteRuleBodyList{}, err
+		return ResponseSiteRuleBodyList{}, logError(1, fmt.Errorf("%s with %s %s ", err.Error(), corpName, siteName))
 	}
 
 	var responseRulesList ResponseSiteRuleBodyList
@@ -1972,7 +1972,7 @@ func (sc Client) GetSiteListByID(corpName, siteName string, id string) (Response
 func (sc Client) GetAllSiteLists(corpName, siteName string) (ResponseListBodyList, error) {
 	resp, err := sc.doRequest("GET", fmt.Sprintf("/v0/corps/%s/sites/%s/lists", corpName, siteName), "")
 	if err != nil {
-		return ResponseListBodyList{}, logError(1, fmt.Errorf("%s", err.Error()))
+		return ResponseListBodyList{}, logError(1, fmt.Errorf("%s with %s %s ", err.Error(), corpName, siteName))
 	}
 	var responseListBodyList ResponseListBodyList
 	err = json.Unmarshal(resp, &responseListBodyList)
@@ -2079,7 +2079,7 @@ func (sc *Client) GetAllSiteRedactions(corpName, siteName string) (ResponseSiteR
 	resp, err := sc.doRequest("GET", fmt.Sprintf("/v0/corps/%s/sites/%s/redactions", corpName, siteName), "")
 
 	if err != nil {
-		return ResponseSiteRedactionBodyList{}, err
+		return ResponseSiteRedactionBodyList{}, logError(1, fmt.Errorf("%s with %s %s ", err.Error(), corpName, siteName))
 	}
 
 	var responseRulesList ResponseSiteRuleBodyList
@@ -2146,7 +2146,7 @@ func (sc Client) GetCorpRuleByID(corpName, id string) (ResponseCorpRuleBody, err
 func (sc Client) GetAllCorpRules(corpName string) (ResponseCorpRuleBodyList, error) {
 	resp, err := sc.doRequest("GET", fmt.Sprintf("/v0/corps/%s/rules", corpName), "")
 	if err != nil {
-		return ResponseCorpRuleBodyList{}, logError(1, fmt.Errorf("%s", err.Error()))
+		return ResponseCorpRuleBodyList{}, logError(1, fmt.Errorf("%s with %s", err.Error(), corpName))
 	}
 	var responseRuleBodyList ResponseCorpRuleBodyList
 	err = json.Unmarshal(resp, &responseRuleBodyList)
@@ -2213,7 +2213,7 @@ func (sc Client) GetCorpListByID(corpName string, id string) (ResponseListBody, 
 func (sc Client) GetAllCorpLists(corpName string) (ResponseListBodyList, error) {
 	resp, err := sc.doRequest("GET", fmt.Sprintf("/v0/corps/%s/lists", corpName), "")
 	if err != nil {
-		return ResponseListBodyList{}, logError(1, fmt.Errorf("%s", err.Error()))
+		return ResponseListBodyList{}, logError(1, fmt.Errorf("%s with %s", err.Error(), corpName))
 	}
 	var responseListBodyList ResponseListBodyList
 	err = json.Unmarshal(resp, &responseListBodyList)
@@ -2305,7 +2305,7 @@ func (sc Client) GetCorpSignalTagByID(corpName string, id string) (ResponseSigna
 func (sc Client) GetAllCorpSignalTags(corpName string) (ResponseSignalTagBodyList, error) {
 	resp, err := sc.doRequest("GET", fmt.Sprintf("/v0/corps/%s/tags", corpName), "")
 	if err != nil {
-		return ResponseSignalTagBodyList{}, logError(1, fmt.Errorf("%s", err.Error()))
+		return ResponseSignalTagBodyList{}, logError(1, fmt.Errorf("%s with %s ", err.Error(), corpName))
 	}
 	var responseSignalTagBodyList ResponseSignalTagBodyList
 	err = json.Unmarshal(resp, &responseSignalTagBodyList)
@@ -2371,7 +2371,7 @@ func (sc Client) GetSiteSignalTagByID(corpName, siteName, id string) (ResponseSi
 func (sc Client) GetAllSiteSignalTags(corpName, siteName string) (ResponseSignalTagBodyList, error) {
 	resp, err := sc.doRequest("GET", fmt.Sprintf("/v0/corps/%s/sites/%s/tags", corpName, siteName), "")
 	if err != nil {
-		return ResponseSignalTagBodyList{}, logError(1, fmt.Errorf("%s", err.Error()))
+		return ResponseSignalTagBodyList{}, logError(1, fmt.Errorf("%s with %s %s ", err.Error(), corpName, siteName))
 	}
 	var responseSignalTagBodyList ResponseSignalTagBodyList
 	err = json.Unmarshal(resp, &responseSignalTagBodyList)

--- a/api.go
+++ b/api.go
@@ -569,8 +569,8 @@ func (sc Client) GetAllCustomSiteAlerts(corpName, siteName string) (ResponseCust
 	return car, nil
 }
 
-// CreateCustomSiteAlert creates a custom alert.
-func (sc Client) CreateCustomSiteAlert(corpName, siteName string, body CreateCustomAlertBody) (ResponseCustomAlertBody, error) {
+// CreateSiteCustomAlert creates a custom alert.
+func (sc Client) CreateSiteCustomAlert(corpName, siteName string, body CreateCustomAlertBody) (ResponseCustomAlertBody, error) {
 	b, err := json.Marshal(body)
 	if err != nil {
 		return ResponseCustomAlertBody{}, err
@@ -590,8 +590,8 @@ func (sc Client) CreateCustomSiteAlert(corpName, siteName string, body CreateCus
 	return c, nil
 }
 
-// GetCustomSiteAlertByID gets a custom alert by ID
-func (sc Client) GetCustomSiteAlertByID(corpName, siteName, id string) (ResponseCustomAlertBody, error) {
+// GetSiteCustomAlertByID gets a custom alert by ID
+func (sc Client) GetSiteCustomAlertByID(corpName, siteName, id string) (ResponseCustomAlertBody, error) {
 	resp, err := sc.doRequest("GET", fmt.Sprintf("/v0/corps/%s/sites/%s/alerts/%s", corpName, siteName, id), "")
 	if err != nil {
 		return ResponseCustomAlertBody{}, err
@@ -606,8 +606,8 @@ func (sc Client) GetCustomSiteAlertByID(corpName, siteName, id string) (Response
 	return ca, nil
 }
 
-// UpdateCustomSiteAlertByID updates a custom alert by id.
-func (sc Client) UpdateCustomSiteAlertByID(corpName, siteName, id string, body CreateCustomAlertBody) (ResponseCustomAlertBody, error) {
+// UpdateSiteCustomAlertByID updates a custom alert by id.
+func (sc Client) UpdateSiteCustomAlertByID(corpName, siteName, id string, body CreateCustomAlertBody) (ResponseCustomAlertBody, error) {
 	b, err := json.Marshal(body)
 	if err != nil {
 		return ResponseCustomAlertBody{}, logError(1, fmt.Errorf("%s with input %#v", err.Error(), string(b)))
@@ -627,8 +627,8 @@ func (sc Client) UpdateCustomSiteAlertByID(corpName, siteName, id string, body C
 	return c, err
 }
 
-// DeleteCustomSiteAlertByID deletes a custom alert.
-func (sc Client) DeleteCustomSiteAlertByID(corpName, siteName, id string) error {
+// DeleteSiteCustomAlertByID deletes a custom alert.
+func (sc Client) DeleteSiteCustomAlertByID(corpName, siteName, id string) error {
 	_, err := sc.doRequest("DELETE", fmt.Sprintf("/v0/corps/%s/sites/%s/alerts/%s", corpName, siteName, id), "")
 
 	return err
@@ -2262,13 +2262,13 @@ type UpdateSignalTagBody struct {
 //ResponseSignalTagBody response singnal tag
 type ResponseSignalTagBody struct {
 	CreateSignalTagBody
-	TagName       string    `json:"tagName",omitempty"`  //The identifier for the signal tag
-	LongName      string    `json:"longName",omitempty"` //The display name of the signal tag - deprecated
-	Configurable  bool      `json:"configurable",omitempty"`
-	Informational bool      `json:"informational",omitempty"`
-	NeedsResponse bool      `json:"needsResponse",omitempty"`
-	CreatedBy     string    `json:"createdBy",omitempty"` //Email address of the user that created the resource
-	Created       time.Time `json:"created",omitempty"`   //Created RFC3339 date time
+	TagName       string    `json:"tagName,omitempty"`  //The identifier for the signal tag
+	LongName      string    `json:"longName,omitempty"` //The display name of the signal tag - deprecated
+	Configurable  bool      `json:"configurable,omitempty"`
+	Informational bool      `json:"informational,omitempty"`
+	NeedsResponse bool      `json:"needsResponse,omitempty"`
+	CreatedBy     string    `json:"createdBy,omitempty"` //Email address of the user that created the resource
+	Created       time.Time `json:"created,omitempty"`   //Created RFC3339 date time
 }
 
 //ResponseSingnalTagBodyList response list

--- a/api.go
+++ b/api.go
@@ -531,21 +531,25 @@ func (sc *Client) UpdateSite(corpName, siteName string, body UpdateSiteBody) (Si
 
 // CreateCustomAlertBody is the body for creating a custom alert.
 type CreateCustomAlertBody struct {
-	TagName   string `json:"tagName"`
-	LongName  string `json:"longName"`
-	Interval  int    `json:"interval"`
-	Threshold int    `json:"threshold"`
-	Enabled   bool   `json:"enabled"`
-	Action    string `json:"action"`
+	TagName              string `json:"tagName,omitempty"`    //The name of the tag whose occurrences the alert is watching. Must match an existing tag
+	LongName             string `json:"longName,omitempty"`   //A human readable description of the alert. Must be between 3 and 25 characters.
+	Interval             int    `json:"interval"`             //The number of minutes of past traffic to examine. Must be 1, 10 or 60.
+	Threshold            int    `json:"threshold"`            //The number of occurrences of the tag in the interval needed to trigger the alert.
+	BlockDurationSeconds int    `json:"blockDurationSeconds"` //The number of seconds this alert is active.
+	Enabled              bool   `json:"enabled"`              //A flag to toggle this alert.
+	Action               string `json:"action,omitempty"`     //A flag that describes what happens when the alert is triggered. 'info' creates an incident in the dashboard. 'flagged' creates an incident and blocks traffic for 24 hours.
 }
 
 //ResponseCustomAlertBody contains the data for a custom alert
 type ResponseCustomAlertBody struct {
 	CreateCustomAlertBody
-	ID        string
-	Created   time.Time
-	CreatedBy string
-	Updated   time.Time
+	ID                string    `json:"id,omitempty"`      //Site-specific unique ID of the alert
+	Type              string    `json:"type,omitempty"`    //Type of alert (siteAlert, template, rateLimit, siteMetric)
+	SkipNotifications bool      `json:"skipNotifications"` //A flag to disable external notifications - slack, webhooks, emails, etc.
+	FieldName         string    `json:"fieldName,omitempty"`
+	CreatedBy         string    `json:"createdBy,omitempty"` //The email of the user that created the alert
+	Created           time.Time `json:"created,omitempty"`   //Created RFC3339 date time
+	Operator          string
 }
 
 // ResponseCustomAlertsBodyList is the response for the alerts endpoint
@@ -586,7 +590,6 @@ func (sc Client) CreateSiteCustomAlert(corpName, siteName string, body CreateCus
 	if err != nil {
 		return ResponseCustomAlertBody{}, err
 	}
-
 	return c, nil
 }
 

--- a/api.go
+++ b/api.go
@@ -1811,12 +1811,7 @@ func (sc *Client) CreateSiteRules(corpName string, siteName string, body CreateS
 	if err != nil {
 		return ResponseSiteRulesBody{}, err
 	}
-	var responseSiteRules ResponseSiteRulesBody
-	err = json.Unmarshal(resp, &responseSiteRules)
-	if err != nil {
-		return ResponseSiteRulesBody{}, err
-	}
-	return responseSiteRules, nil
+	return getResponseSiteRulesBody(resp)
 }
 
 // UpdateSiteRule updates a rule and returns a response
@@ -1829,18 +1824,29 @@ func (sc *Client) UpdateSiteRule(corpName string, siteName string, id string, bo
 	if err != nil {
 		return ResponseSiteRulesBody{}, err
 	}
-	var responseSiteRules ResponseSiteRulesBody
-	err = json.Unmarshal(resp, &responseSiteRules)
-	if err != nil {
-		return ResponseSiteRulesBody{}, err
-	}
-	return responseSiteRules, nil
+	return getResponseSiteRulesBody(resp)
 }
 
 // DeleteSiteRule deletes a rule and returns an error
 func (sc *Client) DeleteSiteRule(corpName string, siteName string, id string) error {
 	_, err := sc.doRequest("DELETE", fmt.Sprintf("/v0/corps/%s/sites/%s/rules/%s", corpName, siteName, id), "")
 	return err
+}
+func (sc *Client) GetSiteRuleById(corpName string, siteName string, id string) (ResponseSiteRulesBody, error) {
+	resp, err := sc.doRequest("GET", fmt.Sprintf("/v0/corps/%s/sites/%s/rules/%s", corpName, siteName, id), "")
+	if err != nil {
+		return ResponseSiteRulesBody{}, err
+	}
+	return getResponseSiteRulesBody(resp)
+}
+
+func getResponseSiteRulesBody(response []byte) (ResponseSiteRulesBody, error) {
+	var responseSiteRules ResponseSiteRulesBody
+	err := json.Unmarshal(response, &responseSiteRules)
+	if err != nil {
+		return ResponseSiteRulesBody{}, err
+	}
+	return responseSiteRules, nil
 }
 
 // ResponseSiteRulesListData contains the returned rules

--- a/api.go
+++ b/api.go
@@ -557,8 +557,8 @@ type ResponseCustomAlertsBodyList struct {
 	Data []ResponseCustomAlertBody
 }
 
-// GetAllCustomSiteAlerts lists custom alerts for a given corp and site.
-func (sc Client) GetAllCustomSiteAlerts(corpName, siteName string) (ResponseCustomAlertsBodyList, error) {
+// GetAllSiteCustomAlerts lists custom alerts for a given corp and site.
+func (sc Client) GetAllSiteCustomAlerts(corpName, siteName string) (ResponseCustomAlertsBodyList, error) {
 	resp, err := sc.doRequest("GET", fmt.Sprintf("/v0/corps/%s/sites/%s/alerts", corpName, siteName), "")
 	if err != nil {
 		return ResponseCustomAlertsBodyList{}, err
@@ -2274,8 +2274,8 @@ type ResponseSignalTagBody struct {
 	Created       time.Time `json:"created,omitempty"`   //Created RFC3339 date time
 }
 
-//ResponseSingnalTagBodyList response list
-type ResponseSingnalTagBodyList struct {
+//ResponseSignalTagBodyList response list
+type ResponseSignalTagBodyList struct {
 	Data []ResponseSignalTagBody `json:"data"` //ResponseSignalTagBody
 }
 
@@ -2302,15 +2302,15 @@ func (sc Client) GetCorpSignalTagByID(corpName string, id string) (ResponseSigna
 }
 
 //GetAllCorpSignalTags get all corp signals
-func (sc Client) GetAllCorpSignalTags(corpName string) (ResponseSingnalTagBodyList, error) {
+func (sc Client) GetAllCorpSignalTags(corpName string) (ResponseSignalTagBodyList, error) {
 	resp, err := sc.doRequest("GET", fmt.Sprintf("/v0/corps/%s/tags", corpName), "")
 	if err != nil {
-		return ResponseSingnalTagBodyList{}, logError(1, fmt.Errorf("%s", err.Error()))
+		return ResponseSignalTagBodyList{}, logError(1, fmt.Errorf("%s", err.Error()))
 	}
-	var responseSignalTagBodyList ResponseSingnalTagBodyList
+	var responseSignalTagBodyList ResponseSignalTagBodyList
 	err = json.Unmarshal(resp, &responseSignalTagBodyList)
 	if err != nil {
-		return ResponseSingnalTagBodyList{}, err
+		return ResponseSignalTagBodyList{}, err
 	}
 	return responseSignalTagBodyList, nil
 }
@@ -2368,15 +2368,15 @@ func (sc Client) GetSiteSignalTagByID(corpName, siteName, id string) (ResponseSi
 }
 
 //GetAllSiteSignalTags get all site signals
-func (sc Client) GetAllSiteSignalTags(corpName, siteName string) (ResponseSingnalTagBodyList, error) {
+func (sc Client) GetAllSiteSignalTags(corpName, siteName string) (ResponseSignalTagBodyList, error) {
 	resp, err := sc.doRequest("GET", fmt.Sprintf("/v0/corps/%s/sites/%s/tags", corpName, siteName), "")
 	if err != nil {
-		return ResponseSingnalTagBodyList{}, logError(1, fmt.Errorf("%s", err.Error()))
+		return ResponseSignalTagBodyList{}, logError(1, fmt.Errorf("%s", err.Error()))
 	}
-	var responseSignalTagBodyList ResponseSingnalTagBodyList
+	var responseSignalTagBodyList ResponseSignalTagBodyList
 	err = json.Unmarshal(resp, &responseSignalTagBodyList)
 	if err != nil {
-		return ResponseSingnalTagBodyList{}, err
+		return ResponseSignalTagBodyList{}, err
 	}
 	return responseSignalTagBodyList, nil
 }

--- a/api_test.go
+++ b/api_test.go
@@ -61,6 +61,7 @@ func TestGoUserTokenClient(t *testing.T) {
 	}
 }
 func TestCreateDeleteSite(t *testing.T) {
+	t.Skip()
 	sc := NewTokenClient(testcreds.email, testcreds.token)
 	corp := "splunk-testcorp"
 

--- a/api_test.go
+++ b/api_test.go
@@ -171,13 +171,13 @@ func TestCreateReadUpdateDeleteSiteRules(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, createSiteRulesBody, *createResp.CreateSiteRuleBody)
+	assert.Equal(t, createSiteRulesBody, createResp.CreateSiteRuleBody)
 
 	readResp, err := sc.GetSiteRuleByID(corp, site, createResp.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, createSiteRulesBody, *readResp.CreateSiteRuleBody)
+	assert.Equal(t, createSiteRulesBody, readResp.CreateSiteRuleBody)
 	updateSiteRuleBody := CreateSiteRuleBody{
 		Type:          "signal",
 		GroupOperator: "all",
@@ -215,7 +215,7 @@ func TestCreateReadUpdateDeleteSiteRules(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, updateSiteRuleBody, *updateResp.CreateSiteRuleBody)
+	assert.Equal(t, updateSiteRuleBody, updateResp.CreateSiteRuleBody)
 
 	readall, err := sc.GetAllSiteRules(corp, site)
 	if err != nil {
@@ -223,7 +223,7 @@ func TestCreateReadUpdateDeleteSiteRules(t *testing.T) {
 	}
 	assert.Equal(t, 1, len(readall.Data))
 	assert.Equal(t, 1, readall.TotalCount)
-	assert.Equal(t, updateSiteRuleBody, *readall.Data[0].CreateSiteRuleBody)
+	assert.Equal(t, updateSiteRuleBody, readall.Data[0].CreateSiteRuleBody)
 
 	err = sc.DeleteSiteRuleByID(corp, site, createResp.ID)
 	if err != nil {
@@ -314,10 +314,10 @@ func TestCreateReadUpdateDeleteSiteList(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, createSiteListBody, *createresp.CreateListBody)
+	assert.Equal(t, createSiteListBody, createresp.CreateListBody)
 
 	readresp, err := sc.GetSiteListByID(corp, site, createresp.ID)
-	assert.Equal(t, createSiteListBody, *readresp.CreateListBody)
+	assert.Equal(t, createSiteListBody, readresp.CreateListBody)
 
 	updateSiteListBody := UpdateListBody{
 		Description: "Some IPs we are updating in the list",
@@ -330,7 +330,7 @@ func TestCreateReadUpdateDeleteSiteList(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.NotEqual(t, createSiteListBody, *updateresp.CreateListBody)
+	assert.NotEqual(t, createSiteListBody, updateresp.CreateListBody)
 	updatedSiteListBody := CreateListBody{
 		Name:        "My new list",
 		Type:        "ip",
@@ -341,10 +341,10 @@ func TestCreateReadUpdateDeleteSiteList(t *testing.T) {
 			"3.4.5.6",
 		},
 	}
-	assert.Equal(t, updatedSiteListBody, *updateresp.CreateListBody)
+	assert.Equal(t, updatedSiteListBody, updateresp.CreateListBody)
 	readall, err := sc.GetAllSiteLists(corp, site)
 	assert.Equal(t, 1, len(readall.Data))
-	assert.Equal(t, updatedSiteListBody, *readall.Data[0].CreateListBody)
+	assert.Equal(t, updatedSiteListBody, readall.Data[0].CreateListBody)
 	err = sc.DeleteSiteListByID(corp, site, readresp.ID)
 	if err != nil {
 		t.Fatal(err)
@@ -364,7 +364,7 @@ func TestCreateMultipleRedactions(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, createSiteRedactionBody, *createresp.CreateSiteRedactionBody)
+	assert.Equal(t, createSiteRedactionBody, createresp.CreateSiteRedactionBody)
 
 	createSiteRedactionBody2 := CreateSiteRedactionBody{
 		Field:         "cookie",
@@ -374,7 +374,7 @@ func TestCreateMultipleRedactions(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, createSiteRedactionBody2, *createresp2.CreateSiteRedactionBody)
+	assert.Equal(t, createSiteRedactionBody2, createresp2.CreateSiteRedactionBody)
 
 	createSiteRedactionBody3 := CreateSiteRedactionBody{
 		Field:         "cookie",
@@ -384,7 +384,7 @@ func TestCreateMultipleRedactions(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, createSiteRedactionBody3, *createresp3.CreateSiteRedactionBody)
+	assert.Equal(t, createSiteRedactionBody3, createresp3.CreateSiteRedactionBody)
 
 	err = sc.DeleteSiteRedactionByID(corp, site, createresp.ID)
 	if err != nil {
@@ -414,10 +414,10 @@ func TestCreatListUpdateDeleteRedaction(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, createSiteRedactionBody, *createresp.CreateSiteRedactionBody)
+	assert.Equal(t, createSiteRedactionBody, createresp.CreateSiteRedactionBody)
 
 	readresp, err := sc.GetSiteRedactionByID(corp, site, createresp.ID)
-	assert.Equal(t, createSiteRedactionBody, *readresp.CreateSiteRedactionBody)
+	assert.Equal(t, createSiteRedactionBody, readresp.CreateSiteRedactionBody)
 
 	updateSiteRedactionBody := CreateSiteRedactionBody{
 		Field:         "cookie",
@@ -427,12 +427,12 @@ func TestCreatListUpdateDeleteRedaction(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.NotEqual(t, createSiteRedactionBody, *updatedresp.CreateSiteRedactionBody)
-	assert.Equal(t, updateSiteRedactionBody, *updatedresp.CreateSiteRedactionBody)
+	assert.NotEqual(t, createSiteRedactionBody, updatedresp.CreateSiteRedactionBody)
+	assert.Equal(t, updateSiteRedactionBody, updatedresp.CreateSiteRedactionBody)
 	readall, err := sc.GetAllSiteRedactions(corp, site)
 	assert.Equal(t, 1, len(readall.Data))
 	// assert.Equal(t, 1, readall.TotalCount)
-	assert.Equal(t, updateSiteRedactionBody, *readall.Data[0].CreateSiteRedactionBody)
+	assert.Equal(t, updateSiteRedactionBody, readall.Data[0].CreateSiteRedactionBody)
 	err = sc.DeleteSiteRedactionByID(corp, site, createresp.ID)
 	if err != nil {
 		t.Fatal(err)
@@ -528,7 +528,7 @@ func TestCreateReadUpdateDeleteCorpRule(t *testing.T) {
 		t.Fatal(err)
 	}
 	// t.Logf("%#v", createResp.CreateCorpRuleBody)
-	assert.Equal(t, createCorpRuleBody, *createResp.CreateCorpRuleBody)
+	assert.Equal(t, createCorpRuleBody, createResp.CreateCorpRuleBody)
 
 	readResp, err := sc.GetCorpRuleByID(corp, createResp.ID)
 	if err != nil {
@@ -574,11 +574,11 @@ func TestCreateReadUpdateDeleteCorpRule(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, updateCorpRuleBody, *updateResp.CreateCorpRuleBody)
+	assert.Equal(t, updateCorpRuleBody, updateResp.CreateCorpRuleBody)
 	readall, err := sc.GetAllCorpRules(corp)
 	assert.Equal(t, 1, len(readall.Data))
 	assert.Equal(t, 1, readall.TotalCount)
-	assert.Equal(t, updateCorpRuleBody, *readall.Data[0].CreateCorpRuleBody)
+	assert.Equal(t, updateCorpRuleBody, readall.Data[0].CreateCorpRuleBody)
 	err = sc.DeleteCorpRuleByID(corp, createResp.ID)
 
 	if err != nil {
@@ -603,10 +603,10 @@ func TestCreateReadUpdateDeleteCorpList(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, createCorpListBody, *createresp.CreateListBody)
+	assert.Equal(t, createCorpListBody, createresp.CreateListBody)
 
 	readresp, err := sc.GetCorpListByID(corp, createresp.ID)
-	assert.Equal(t, createCorpListBody, *readresp.CreateListBody)
+	assert.Equal(t, createCorpListBody, readresp.CreateListBody)
 
 	updateCorpListBody := UpdateListBody{
 		Description: "Some IPs we are updating in the list",
@@ -619,7 +619,7 @@ func TestCreateReadUpdateDeleteCorpList(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.NotEqual(t, createCorpListBody, *updateresp.CreateListBody)
+	assert.NotEqual(t, createCorpListBody, updateresp.CreateListBody)
 	updatedCorpListBody := CreateListBody{
 		Name:        "My new list",
 		Type:        "ip",
@@ -630,10 +630,10 @@ func TestCreateReadUpdateDeleteCorpList(t *testing.T) {
 			"3.4.5.6",
 		},
 	}
-	assert.Equal(t, updatedCorpListBody, *updateresp.CreateListBody)
+	assert.Equal(t, updatedCorpListBody, updateresp.CreateListBody)
 	readall, err := sc.GetAllCorpLists(corp)
 	assert.Equal(t, 1, len(readall.Data))
-	assert.Equal(t, updatedCorpListBody, *readall.Data[0].CreateListBody)
+	assert.Equal(t, updatedCorpListBody, readall.Data[0].CreateListBody)
 	err = sc.DeleteCorpListByID(corp, readresp.ID)
 	if err != nil {
 		t.Fatal(err)

--- a/api_test.go
+++ b/api_test.go
@@ -407,13 +407,13 @@ func TestSiteCreateReadUpdateDeleteAlerts(t *testing.T) {
 		Enabled:   true,
 		Action:    "flagged",
 	}
-	createresp, err := sc.CreateCustomSiteAlert(corp, site, createCustomAlert)
+	createresp, err := sc.CreateSiteCustomAlert(corp, site, createCustomAlert)
 	// t.Logf("%#v", createresp.Data)
 	if err != nil {
 		t.Fatal(err)
 	}
 	assert.Equal(t, createCustomAlert, createresp.CreateCustomAlertBody)
-	readresp, err := sc.GetCustomSiteAlertByID(corp, site, createresp.ID)
+	readresp, err := sc.GetSiteCustomAlertByID(corp, site, createresp.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -427,7 +427,7 @@ func TestSiteCreateReadUpdateDeleteAlerts(t *testing.T) {
 		Enabled:   true,
 		Action:    "flagged",
 	}
-	updateresp, err := sc.UpdateCustomSiteAlertByID(corp, site, readresp.ID, updateCustomAlert)
+	updateresp, err := sc.UpdateSiteCustomAlertByID(corp, site, readresp.ID, updateCustomAlert)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -441,7 +441,7 @@ func TestSiteCreateReadUpdateDeleteAlerts(t *testing.T) {
 	assert.Equal(t, 1, len(allalerts.Data))
 	assert.Equal(t, updateCustomAlert, allalerts.Data[0].CreateCustomAlertBody)
 	// for _, createresp := range allalerts.Data {
-	err = sc.DeleteCustomSiteAlertByID(corp, site, createresp.ID)
+	err = sc.DeleteSiteCustomAlertByID(corp, site, createresp.ID)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/api_test.go
+++ b/api_test.go
@@ -1,12 +1,27 @@
 package sigsci
 
 import (
+	"encoding/json"
 	"log"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
+type TestCreds struct {
+	email string
+	token string
+}
+
+var testcreds = TestCreds{
+	email: os.Getenv("SIGSCI_EMAIL"),
+	token: os.Getenv("SIGSCI_TOKEN"), //"6b62cee3-bd06-487e-9283-d565078b7a8f",
+}
+
 func ExampleClient_InviteUser() {
-	email := "[email]"
-	password := "[password]"
+	email := testcreds.email
+	password := testcreds.token
 	sc, err := NewClient(email, password)
 	if err != nil {
 		log.Fatal(err)
@@ -19,5 +34,393 @@ func ExampleClient_InviteUser() {
 	_, err = sc.InviteUser("testcorp", "test@test.net", invite)
 	if err != nil {
 		log.Fatal(err)
+	}
+}
+
+func TestGoUserTokenClient(t *testing.T) {
+	testCases := []struct {
+		name  string
+		email string
+		token string
+	}{
+		{
+			name:  "working user pass creds",
+			email: testcreds.email,
+			token: testcreds.token,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			sc := NewTokenClient(testCase.email, testCase.token)
+			if corps, err := sc.ListCorps(); err != nil {
+				t.Fatal(err)
+			} else {
+				assert.Equal(t, "splunk-testcorp", corps[0].Name)
+			}
+		})
+	}
+}
+func TestCreateSite(t *testing.T) {
+	sc := NewTokenClient(testcreds.email, testcreds.token)
+	corp := "splunk-testcorp"
+
+	siteBody := CreateSiteBody{
+		Name:                 "janitha-test-site",
+		DisplayName:          "Janitha Test Site",
+		AgentLevel:           "Log",
+		BlockHTTPCode:        406,
+		BlockDurationSeconds: 86400,
+		AgentAnonMode:        "off",
+	}
+	_, err := sc.CreateSite(corp, siteBody)
+	if err == nil {
+		t.Fatal("Can create more than one site. Clean up not implemented")
+	}
+	assert.Equal(t, "Site limit reached", err.Error())
+
+}
+func TestDeleteSite(t *testing.T) {
+	sc := NewTokenClient(testcreds.email, testcreds.token)
+	corp := "splunk-testcorp"
+	site := "janitha-test-site" //do not have permission at the moment anyway
+	err := sc.DeleteSite(corp, site)
+	if err == nil {
+		t.Fatalf("This site %s should not exist", site)
+	}
+	assert.Equal(t, "Site not found", err.Error())
+}
+func TestGetAlerts(t *testing.T) {
+	t.Skip()
+	sc := NewTokenClient(testcreds.email, testcreds.token)
+	corp := "splunk-tescorp"
+	site := "splunk-test"
+	alert, err := sc.GetCustomAlert(corp, site, "5e828777a981ef01c7107035")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("%+v", alert)
+}
+func TestCreateCustomSiteAlert(t *testing.T) {
+	sc := NewTokenClient(testcreds.email, testcreds.token)
+	corp := "splunk-tescorp"
+	site := "splunk-test"
+	customAlertBody := CustomAlertBody{
+		TagName:   "CMDEXE",
+		LongName:  "Janitha Long Name",
+		Action:    "flagged",
+		Enabled:   true,
+		Interval:  1,
+		Threshold: 1,
+	}
+	alert, err := sc.CreateCustomAlert(corp, site, customAlertBody) //changed the method to POST
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, true, alert.Enabled)
+	customAlertBody = CustomAlertBody{
+		TagName:   "CMDEXE",
+		LongName:  "Janitha Long Name",
+		Action:    "flagged",
+		Enabled:   false,
+		Interval:  1,
+		Threshold: 1,
+	}
+	alertup, err := sc.UpdateCustomAlert(corp, site, alert.ID, customAlertBody)
+	assert.Equal(t, false, alertup.Enabled)
+	assert.Equal(t, alert.ID, alertup.ID)
+	err = sc.DeleteCustomAlert(corp, site, alert.ID)
+	_, err = sc.GetCustomAlert(corp, site, alert.ID)
+	if err == nil { //expect a failure because the ID does not exist
+		t.Fatal(err)
+	}
+	// assert.Equal(t, alert.ID, alertdel.ID)
+}
+
+func TestCreateSiteRules(t *testing.T) {
+
+	siteRulesBody := CreateSiteRulesBody{
+		Type:          "signal",
+		GroupOperator: "all",
+		Enabled:       true,
+		Reason:        "Example site rule",
+		Signal:        "SQLI",
+		Expiration:    "",
+		Conditions: []Condition{
+			Condition{
+				Type:     "single",
+				Field:    "ip",
+				Operator: "equals",
+				Value:    "1.2.3.4",
+			},
+			Condition{
+				Type:          "group",
+				GroupOperator: "any",
+				Conditions: []Condition{
+					Condition{
+						Type:     "single",
+						Field:    "ip",
+						Operator: "equals",
+						Value:    "5.6.7.8",
+					},
+				},
+			},
+		},
+		Actions: []Action{
+			Action{
+				Type: "excludeSignal",
+			},
+		},
+	}
+	sc := NewTokenClient(testcreds.email, testcreds.token)
+	corp := "splunk-tescorp"
+	site := "splunk-test"
+	rules, err := sc.CreateSiteRules(corp, site, siteRulesBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, siteRulesBody, *rules.CreateSiteRulesBody)
+	err = sc.DeleteSiteRule(corp, site, rules.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+func TestUpdateSiteRules(t *testing.T) {
+
+	siteRulesBody := CreateSiteRulesBody{
+		Type:          "signal",
+		GroupOperator: "all",
+		Enabled:       true,
+		Reason:        "Example site rule",
+		Signal:        "SQLI",
+		Expiration:    "",
+		Conditions: []Condition{
+			Condition{
+				Type:     "single",
+				Field:    "ip",
+				Operator: "equals",
+				Value:    "1.2.3.4",
+			},
+			Condition{
+				Type:          "group",
+				GroupOperator: "any",
+				Conditions: []Condition{
+					Condition{
+						Type:     "single",
+						Field:    "ip",
+						Operator: "equals",
+						Value:    "5.6.7.8",
+					},
+				},
+			},
+		},
+		Actions: []Action{
+			Action{
+				Type: "excludeSignal",
+			},
+		},
+	}
+	sc := NewTokenClient(testcreds.email, testcreds.token)
+	corp := "splunk-tescorp"
+	site := "splunk-test"
+	rule, err := sc.CreateSiteRules(corp, site, siteRulesBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, siteRulesBody, *rule.CreateSiteRulesBody)
+
+	siteUpdatedBody := CreateSiteRulesBody{
+		Type:          "signal",
+		GroupOperator: "all",
+		Enabled:       true,
+		Reason:        "Example site rule",
+		Signal:        "SQLI",
+		Expiration:    "",
+		Conditions: []Condition{
+			Condition{
+				Type:     "single",
+				Field:    "ip",
+				Operator: "equals",
+				Value:    "1.2.3.4",
+			},
+			Condition{
+				Type:          "group",
+				GroupOperator: "any",
+				Conditions: []Condition{
+					Condition{
+						Type:     "single",
+						Field:    "ip",
+						Operator: "equals",
+						Value:    "9.10.11.12",
+					},
+				},
+			},
+		},
+		Actions: []Action{
+			Action{
+				Type: "excludeSignal",
+			},
+		},
+	}
+	updatedRule, err := sc.UpdateSiteRule(corp, site, *&rule.ID, siteUpdatedBody)
+	assert.Equal(t, siteUpdatedBody, *updatedRule.CreateSiteRulesBody)
+	err = sc.DeleteSiteRule(corp, site, rule.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+func TestListSiteRules(t *testing.T) {
+	sc := NewTokenClient(testcreds.email, testcreds.token)
+	corp := "splunk-tescorp"
+	site := "splunk-test"
+	_, err := sc.ListSiteRules(corp, site)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestUnMarshalListData(t *testing.T) {
+	resp := []byte(`{
+		"totalCount": 1,
+		"data": [
+		  {
+			"id": "5e84ec28bf612801c7f0f109",
+			"siteNames": [
+			  "splunk-test"
+			],
+			"type": "signal",
+			"enabled": true,
+			"groupOperator": "all",
+			"conditions": [
+			  {
+				"type": "single",
+				"field": "ip",
+				"operator": "equals",
+				"value": "1.2.3.4"
+			  }
+			],
+			"actions": [
+			  {
+				"type": "excludeSignal"
+			  }
+			],
+			"signal": "SQLI",
+			"reason": "Example site rule",
+			"expiration": "",
+			"createdBy": "janitha.jayaweera@gmail.com",
+			"created": "2020-04-01T19:31:52Z",
+			"updated": "2020-04-01T19:31:52Z"
+		  }
+		]
+	  }`)
+
+	var responseRulesList ResponseSiteRulesListData
+	err := json.Unmarshal(resp, &responseRulesList)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, 1, responseRulesList.TotalCount)
+	assert.Equal(t, 1, len(responseRulesList.Data))
+	assert.Equal(t, "5e84ec28bf612801c7f0f109", responseRulesList.Data[0].ID)
+}
+
+func TestDeleteAllSiteRules(t *testing.T) {
+	t.SkipNow()
+	sc := NewTokenClient(testcreds.email, testcreds.token)
+	corp := "splunk-tescorp"
+	site := "splunk-test"
+	respList, err := sc.ListSiteRules(corp, site)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// assert.Equal(t, 0, len(respList))
+	for _, rule := range respList {
+		sc.DeleteSiteRule(corp, site, rule.ID)
+	}
+	respList, err = sc.ListSiteRules(corp, site)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, 0, len(respList))
+}
+
+func TestGetSiteRuleById(t *testing.T) {
+	siteRulesBody := CreateSiteRulesBody{
+		Type:          "signal",
+		GroupOperator: "all",
+		Enabled:       true,
+		Reason:        "Example site rule",
+		Signal:        "SQLI",
+		Expiration:    "",
+		Conditions: []Condition{
+			Condition{
+				Type:     "single",
+				Field:    "ip",
+				Operator: "equals",
+				Value:    "1.2.3.4",
+			},
+			Condition{
+				Type:          "group",
+				GroupOperator: "any",
+				Conditions: []Condition{
+					Condition{
+						Type:     "single",
+						Field:    "ip",
+						Operator: "equals",
+						Value:    "5.6.7.8",
+					},
+				},
+			},
+		},
+		Actions: []Action{
+			Action{
+				Type: "excludeSignal",
+			},
+		},
+	}
+	sc := NewTokenClient(testcreds.email, testcreds.token)
+	corp := "splunk-tescorp"
+	site := "splunk-test"
+	rule, err := sc.CreateSiteRules(corp, site, siteRulesBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, siteRulesBody, *rule.CreateSiteRulesBody)
+
+	readRule, err := sc.GetSiteRuleById(corp, site, *&rule.ID)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, siteRulesBody, *readRule.CreateSiteRulesBody)
+
+	err = sc.DeleteSiteRule(corp, site, rule.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+func TestSigSciAPI(t *testing.T) {
+	testCases := map[string]map[string]func(t *testing.T){
+		"Site": {
+			"create": TestCreateSite,
+			"delete": TestDeleteSite,
+		},
+		"Rule": {
+			"list":               TestListSiteRules,
+			"createdelete":       TestCreateSiteRules,
+			"createreaddelete":   TestGetSiteRuleById,
+			"createupdatedelete": TestUpdateSiteRules,
+			"delete":             TestDeleteAllSiteRules,
+		},
+	}
+	for group, m := range testCases {
+		m := m
+		t.Run(group, func(t *testing.T) {
+			for name, tc := range m {
+				tc := tc
+				t.Run(name, func(t *testing.T) {
+					tc(t)
+				})
+			}
+		})
 	}
 }

--- a/api_test.go
+++ b/api_test.go
@@ -400,12 +400,13 @@ func TestSiteCreateReadUpdateDeleteAlerts(t *testing.T) {
 	site := "splunk-test"
 
 	createCustomAlert := CreateCustomAlertBody{
-		TagName:   "SQLI",
-		LongName:  "Example Alert",
-		Interval:  1,
-		Threshold: 10,
-		Enabled:   true,
-		Action:    "flagged",
+		TagName:              "SQLI",
+		LongName:             "Example Alert",
+		BlockDurationSeconds: 1,
+		Interval:             1,
+		Threshold:            10,
+		Enabled:              true,
+		Action:               "flagged",
 	}
 	createresp, err := sc.CreateSiteCustomAlert(corp, site, createCustomAlert)
 	// t.Logf("%#v", createresp.Data)
@@ -420,12 +421,13 @@ func TestSiteCreateReadUpdateDeleteAlerts(t *testing.T) {
 	assert.Equal(t, createCustomAlert, readresp.CreateCustomAlertBody)
 
 	updateCustomAlert := CreateCustomAlertBody{
-		TagName:   "SQLI",
-		LongName:  "Example Alert Updated",
-		Interval:  10,
-		Threshold: 10,
-		Enabled:   true,
-		Action:    "flagged",
+		TagName:              "SQLI",
+		LongName:             "Example Alert Updated",
+		BlockDurationSeconds: 1,
+		Interval:             10,
+		Threshold:            10,
+		Enabled:              true,
+		Action:               "flagged",
 	}
 	updateresp, err := sc.UpdateSiteCustomAlertByID(corp, site, readresp.ID, updateCustomAlert)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,6 @@ module github.com/signalsciences/go-sigsci
 
 go 1.12
 
-require github.com/stretchr/testify v1.5.1
+require (
+	github.com/stretchr/testify v1.5.1
+)

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/signalsciences/go-sigsci
 
 go 1.12
+
+require github.com/stretchr/testify v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
+github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
I am working on writing a terraform provider for sigsci, and it looks like we need to expand the sigsci golang client to be able to hit some new API endpoints. Janitha at splunk has written a bunch of code to get their internal implementation to work. The endpoints we need in particular are all of the SiteRule, SiteList, and Redactions related endpoints he has written here.  I am testing out each endpoint now, but it seems to be working so far and I wanted your thoughts on if we could/should merge this since we need most of this functionality anyways. If so are there any changes we should make? We probably don't need the .devcontainer stuff