### PR TITLE
Extend site config to return ClientIPRules - fixes #47 

### DIFF
--- a/api.go
+++ b/api.go
@@ -455,6 +455,10 @@ func (sc *Client) ListCorpActivity(corpName string, limit, page int) ([]Activity
 	return ar.Data, nil
 }
 
+type ClientIPRules struct {
+	Header string `json:"header"`
+}
+
 // Site contains details for a site.
 type Site struct {
 	Name                 string
@@ -480,6 +484,7 @@ type Site struct {
 	TopAttacks           map[string]string
 	Members              map[string]string
 	AgentAnonMode        string
+	ClientIPRules        ClientIPRules
 }
 
 // sitesResponse is the response for list sites.
@@ -521,11 +526,12 @@ func (sc *Client) GetSite(corpName, siteName string) (Site, error) {
 
 // UpdateSiteBody is the body for the update site method.
 type UpdateSiteBody struct {
-	DisplayName          string `json:"displayName,omitempty"`
-	AgentLevel           string `json:"agentLevel,omitempty"`
-	BlockDurationSeconds int    `json:"blockDurationSeconds,omitempty"`
-	BlockHTTPCode        int    `json:"blockHTTPCode,omitempty"`
-	AgentAnonMode        string `json:"agentAnonMode"`
+	DisplayName          string        `json:"displayName,omitempty"`
+	AgentLevel           string        `json:"agentLevel,omitempty"`
+	BlockDurationSeconds int           `json:"blockDurationSeconds,omitempty"`
+	BlockHTTPCode        int           `json:"blockHTTPCode,omitempty"`
+	AgentAnonMode        string        `json:"agentAnonMode"`
+	ClientIPRules        ClientIPRules `json:"clientIPRules"`
 }
 
 // UpdateSite updates a site by name.
@@ -2085,12 +2091,13 @@ func (sc *Client) GetTimeseries(corpName, siteName string, query url.Values) ([]
 
 // CreateSiteBody is the structure required to create a Site.
 type CreateSiteBody struct {
-	Name                 string `json:"name,omitempty"`                 //Identifying name of the site
-	DisplayName          string `json:"displayName,omitempty"`          //Display name of the site
-	AgentLevel           string `json:"agentLevel,omitempty"`           //Agent action level - 'block', 'log' or 'off'
-	AgentAnonMode        string `json:"agentAnonMode"`                  //Agent IP anonimization mode - 'EU' or ''
-	BlockHTTPCode        int    `json:"blockHTTPCode,omitempty"`        //HTTP response code to send when when traffic is being blocked
-	BlockDurationSeconds int    `json:"blockDurationSeconds,omitempty"` //Duration to block an IP in seconds
+	Name                 string        `json:"name,omitempty"`                 //Identifying name of the site
+	DisplayName          string        `json:"displayName,omitempty"`          //Display name of the site
+	AgentLevel           string        `json:"agentLevel,omitempty"`           //Agent action level - 'block', 'log' or 'off'
+	AgentAnonMode        string        `json:"agentAnonMode"`                  //Agent IP anonymization mode - 'EU' or ''
+	BlockHTTPCode        int           `json:"blockHTTPCode,omitempty"`        //HTTP response code to send when traffic is being blocked
+	BlockDurationSeconds int           `json:"blockDurationSeconds,omitempty"` //Duration to block an IP in seconds
+	ClientIPRules        ClientIPRules `json:"clientIPRules"`                  //The specified header to assign client IPs to requests.
 }
 
 // CreateSite Creates a site in a corp.

--- a/api.go
+++ b/api.go
@@ -2103,7 +2103,6 @@ type CreateSiteBody struct {
 // CreateSite Creates a site in a corp.
 func (sc *Client) CreateSite(corpName string, body CreateSiteBody) (Site, error) {
 	b, err := json.Marshal(body)
-	fmt.Println(string(b))
 	if err != nil {
 		return Site{}, err
 	}

--- a/api.go
+++ b/api.go
@@ -455,7 +455,7 @@ func (sc *Client) ListCorpActivity(corpName string, limit, page int) ([]Activity
 	return ar.Data, nil
 }
 
-type ClientIPRules struct {
+type ClientIPRules []struct {
 	Header string `json:"header"`
 }
 
@@ -2103,6 +2103,7 @@ type CreateSiteBody struct {
 // CreateSite Creates a site in a corp.
 func (sc *Client) CreateSite(corpName string, body CreateSiteBody) (Site, error) {
 	b, err := json.Marshal(body)
+	fmt.Println(string(b))
 	if err != nil {
 		return Site{}, err
 	}

--- a/api_test.go
+++ b/api_test.go
@@ -94,7 +94,6 @@ func TestCreateUpdateDeleteSite(t *testing.T) {
 			{"X-Forwarded-For"},
 		},
 	}
-	fmt.Println(siteBody)
 	siteresponse, err := sc.CreateSite(corp, siteBody)
 	if err != nil {
 		t.Fatal(err)

--- a/api_test.go
+++ b/api_test.go
@@ -90,6 +90,9 @@ func TestCreateUpdateDeleteSite(t *testing.T) {
 		BlockHTTPCode:        406,   // TODO test non-default value once api supports it
 		BlockDurationSeconds: 86400, // TODO test non-default value once api supports it
 		AgentAnonMode:        "",
+		ClientIPRules: ClientIPRules{
+			"X-Forwarded-For",
+		},
 	}
 	siteresponse, err := sc.CreateSite(corp, siteBody)
 	if err != nil {
@@ -110,6 +113,9 @@ func TestCreateUpdateDeleteSite(t *testing.T) {
 	if siteresponse.AgentAnonMode != "" {
 		t.Errorf("AgentAnonMode got %s expected %s", siteresponse.AgentAnonMode, "")
 	}
+	if siteresponse.ClientIPRules.Header != "" {
+		t.Errorf("ClientIPRules got %s expected %s", siteresponse.ClientIPRules.Header, "")
+	}
 
 	updateSite, err := sc.UpdateSite(corp, siteBody.Name, UpdateSiteBody{
 		DisplayName:          "Test Site 2",
@@ -117,6 +123,9 @@ func TestCreateUpdateDeleteSite(t *testing.T) {
 		BlockDurationSeconds: 86402,
 		BlockHTTPCode:        406, // TODO increment this value once api supports it
 		AgentAnonMode:        "EU",
+		ClientIPRules: ClientIPRules{
+			"Fastly-Client-IP",
+		},
 	})
 
 	if err != nil {
@@ -137,6 +146,9 @@ func TestCreateUpdateDeleteSite(t *testing.T) {
 	}
 	if updateSite.AgentAnonMode != "EU" {
 		t.Errorf("AgentAnonMode got %s expected %s", updateSite.AgentAnonMode, "EU")
+	}
+	if updateSite.ClientIPRules.Header != "Fastly-Client-IP" {
+		t.Errorf("ClientIPRules got %s expected %s", updateSite.ClientIPRules.Header, "EU")
 	}
 
 	err = sc.DeleteSite(corp, siteBody.Name)

--- a/api_test.go
+++ b/api_test.go
@@ -91,9 +91,10 @@ func TestCreateUpdateDeleteSite(t *testing.T) {
 		BlockDurationSeconds: 86400, // TODO test non-default value once api supports it
 		AgentAnonMode:        "",
 		ClientIPRules: ClientIPRules{
-			"X-Forwarded-For",
+			{"X-Forwarded-For"},
 		},
 	}
+	fmt.Println(siteBody)
 	siteresponse, err := sc.CreateSite(corp, siteBody)
 	if err != nil {
 		t.Fatal(err)
@@ -113,8 +114,10 @@ func TestCreateUpdateDeleteSite(t *testing.T) {
 	if siteresponse.AgentAnonMode != "" {
 		t.Errorf("AgentAnonMode got %s expected %s", siteresponse.AgentAnonMode, "")
 	}
-	if siteresponse.ClientIPRules.Header != "" {
-		t.Errorf("ClientIPRules got %s expected %s", siteresponse.ClientIPRules.Header, "")
+	for _, h := range siteresponse.ClientIPRules {
+		if h.Header != "X-Forwarded-For" {
+			t.Errorf("ClientIPRules got %s expected %s", h.Header, "X-Forwarded-For")
+		}
 	}
 
 	updateSite, err := sc.UpdateSite(corp, siteBody.Name, UpdateSiteBody{
@@ -124,7 +127,7 @@ func TestCreateUpdateDeleteSite(t *testing.T) {
 		BlockHTTPCode:        406, // TODO increment this value once api supports it
 		AgentAnonMode:        "EU",
 		ClientIPRules: ClientIPRules{
-			"Fastly-Client-IP",
+			{"Fastly-Client-IP"},
 		},
 	})
 
@@ -147,8 +150,10 @@ func TestCreateUpdateDeleteSite(t *testing.T) {
 	if updateSite.AgentAnonMode != "EU" {
 		t.Errorf("AgentAnonMode got %s expected %s", updateSite.AgentAnonMode, "EU")
 	}
-	if updateSite.ClientIPRules.Header != "Fastly-Client-IP" {
-		t.Errorf("ClientIPRules got %s expected %s", updateSite.ClientIPRules.Header, "EU")
+	for _, h := range updateSite.ClientIPRules {
+		if h.Header != "Fastly-Client-IP" {
+			t.Errorf("ClientIPRules got %s expected %s", h.Header, "Fastly-Client-IP")
+		}
 	}
 
 	err = sc.DeleteSite(corp, siteBody.Name)


### PR DESCRIPTION
This commit extends go-sigsci to include the clientIPRules in the response as it does when set via:
[https://dashboard.signalsciences.net/corps/<corp>/sites/<site>/edit#config](https://dashboard.signalsciences.net/corps/<corp>/sites/<site>/edit#config)

This fixes:
https://github.com/signalsciences/go-sigsci/issues/47


