### PR TITLE
Add new EdgeDeployment arguments

### DIFF
--- a/api.go
+++ b/api.go
@@ -2901,14 +2901,24 @@ func (sc *Client) DeleteEdgeDeployment(corpName, siteName string) error {
 	return err
 }
 
+type CreateOrUpdateEdgeDeploymentServiceBody struct {
+	ActivateVersion      bool          `json:"activateVersion,omitempty"`      //Activate Fastly VCL service after clone
+	PercentEnabled       int           `json:"percentEnabled,omitempty"`       //Percentage of traffic to send to NGWAF@Edge
+}
+
 // CreateOrUpdateEdgeDeploymentService copies the backends from the Fastly service to the
 // Edge Deployment and pre-configures the Fastly service with an edge dictionary and custom VCL.
-func (sc *Client) CreateOrUpdateEdgeDeploymentService(corpName, siteName, fastlySID string) error {
+func (sc *Client) CreateOrUpdateEdgeDeploymentService(corpName, siteName, fastlySID string, body CreateOrUpdateEdgeDeploymentServiceBody) error {
+	b, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+
 	if sc.fastlyKey == "" {
 		return errors.New("please set Fastly-Key with the client.SetFastlyKey method")
 	}
 
-	_, err := sc.doRequest("PUT", fmt.Sprintf("/v0/corps/%s/sites/%s/edgeDeployment/%s", corpName, siteName, fastlySID), "")
+	_, err = sc.doRequest("PUT", fmt.Sprintf("/v0/corps/%s/sites/%s/edgeDeployment/%s", corpName, siteName, fastlySID), string(b))
 
 	return err
 }

--- a/api.go
+++ b/api.go
@@ -2902,8 +2902,8 @@ func (sc *Client) DeleteEdgeDeployment(corpName, siteName string) error {
 }
 
 type CreateOrUpdateEdgeDeploymentServiceBody struct {
-	ActivateVersion      bool          `json:"activateVersion,omitempty"`      //Activate Fastly VCL service after clone
-	PercentEnabled       int           `json:"percentEnabled,omitempty"`       //Percentage of traffic to send to NGWAF@Edge
+	ActivateVersion *bool `json:"activateVersion,omitempty"` //Activate Fastly VCL service after clone
+	PercentEnabled  int   `json:"percentEnabled,omitempty"`  //Percentage of traffic to send to NGWAF@Edge
 }
 
 // CreateOrUpdateEdgeDeploymentService copies the backends from the Fastly service to the

--- a/api.go
+++ b/api.go
@@ -2909,13 +2909,13 @@ type CreateOrUpdateEdgeDeploymentServiceBody struct {
 // CreateOrUpdateEdgeDeploymentService copies the backends from the Fastly service to the
 // Edge Deployment and pre-configures the Fastly service with an edge dictionary and custom VCL.
 func (sc *Client) CreateOrUpdateEdgeDeploymentService(corpName, siteName, fastlySID string, body CreateOrUpdateEdgeDeploymentServiceBody) error {
+	if sc.fastlyKey == "" {
+		return errors.New("please set Fastly-Key with the client.SetFastlyKey method")
+	}
+
 	b, err := json.Marshal(body)
 	if err != nil {
 		return err
-	}
-
-	if sc.fastlyKey == "" {
-		return errors.New("please set Fastly-Key with the client.SetFastlyKey method")
 	}
 
 	_, err = sc.doRequest("PUT", fmt.Sprintf("/v0/corps/%s/sites/%s/edgeDeployment/%s", corpName, siteName, fastlySID), string(b))


### PR DESCRIPTION
Original PR from @vvuksan is [here](https://github.com/signalsciences/go-sigsci/pull/50)

This adds my commit which updates `ActivateVersion` to a pointer.

> Add support for PercentEnabled and ActivateVersion arguments to the edgeDeployment call.