### PR TITLE
MEDIUM: api: add support for custom response code redirects

### DIFF
--- a/api.go
+++ b/api.go
@@ -466,6 +466,7 @@ type Site struct {
 	AgentLevel           string
 	BlockHTTPCode        int
 	BlockDurationSeconds int
+	BlockRedirectURL     string
 	Created              time.Time
 	Whitelist            map[string]string
 	Blacklist            map[string]string
@@ -530,6 +531,7 @@ type UpdateSiteBody struct {
 	AgentLevel           string        `json:"agentLevel,omitempty"`
 	BlockDurationSeconds int           `json:"blockDurationSeconds,omitempty"`
 	BlockHTTPCode        int           `json:"blockHTTPCode,omitempty"`
+	BlockRedirectURL     string        `json:"blockRedirectURL,omitempty"`
 	AgentAnonMode        string        `json:"agentAnonMode"`
 	ClientIPRules        ClientIPRules `json:"clientIPRules"`
 }
@@ -2096,6 +2098,7 @@ type CreateSiteBody struct {
 	AgentLevel           string        `json:"agentLevel,omitempty"`           //Agent action level - 'block', 'log' or 'off'
 	AgentAnonMode        string        `json:"agentAnonMode"`                  //Agent IP anonymization mode - 'EU' or ''
 	BlockHTTPCode        int           `json:"blockHTTPCode,omitempty"`        //HTTP response code to send when traffic is being blocked
+	BlockRedirectURL     string        `json:"blockRedirectURL,omitempty"`     //URL to redirect to when BlockHTTPCode is 301 or 302
 	BlockDurationSeconds int           `json:"blockDurationSeconds,omitempty"` //Duration to block an IP in seconds
 	ClientIPRules        ClientIPRules `json:"clientIPRules"`                  //The specified header to assign client IPs to requests.
 }
@@ -2145,6 +2148,7 @@ type Action struct {
 	Type         string `json:"type,omitempty"` //(block, allow, exclude)
 	Signal       string `json:"signal,omitempty"`
 	ResponseCode int    `json:"responseCode,omitempty"` //(400-499)
+	RedirectURL  string `json:"redirectURL,omitempty"`  //requires ResponseCode 301 or 302
 }
 
 // ClientIdentifier contains the client identifier fields for site rules of type rate_limit

--- a/api_test.go
+++ b/api_test.go
@@ -87,7 +87,7 @@ func TestCreateUpdateDeleteSite(t *testing.T) {
 		Name:                 "test-site",
 		DisplayName:          "Test Site",
 		AgentLevel:           "block",
-		BlockHTTPCode:        406,   // TODO test non-default value once api supports it
+		BlockHTTPCode:        403,
 		BlockDurationSeconds: 86400, // TODO test non-default value once api supports it
 		AgentAnonMode:        "",
 		ClientIPRules: ClientIPRules{
@@ -104,8 +104,8 @@ func TestCreateUpdateDeleteSite(t *testing.T) {
 	if siteresponse.AgentLevel != "block" {
 		t.Errorf("AgentLevel got %s expected %s", siteresponse.AgentLevel, "block")
 	}
-	if siteresponse.BlockHTTPCode != 406 {
-		t.Errorf("BlockHTTPCode got %d expected %d", siteresponse.BlockHTTPCode, 406)
+	if siteresponse.BlockHTTPCode != 403 {
+		t.Errorf("BlockHTTPCode got %d expected %d", siteresponse.BlockHTTPCode, 403)
 	}
 	if siteresponse.BlockDurationSeconds != 86400 {
 		t.Errorf("BlockDurationSeconds got %d expected %d", siteresponse.BlockDurationSeconds, 86400)
@@ -123,7 +123,8 @@ func TestCreateUpdateDeleteSite(t *testing.T) {
 		DisplayName:          "Test Site 2",
 		AgentLevel:           "off",
 		BlockDurationSeconds: 86402,
-		BlockHTTPCode:        406, // TODO increment this value once api supports it
+		BlockHTTPCode:        302,
+		BlockRedirectURL:     "/blocked",
 		AgentAnonMode:        "EU",
 		ClientIPRules: ClientIPRules{
 			{"Fastly-Client-IP"},
@@ -140,8 +141,11 @@ func TestCreateUpdateDeleteSite(t *testing.T) {
 	if updateSite.AgentLevel != "off" {
 		t.Errorf("AgentLevel got %s expected %s", updateSite.AgentLevel, "off")
 	}
-	if updateSite.BlockHTTPCode != 406 {
-		t.Errorf("BlockHTTPCode got %d expected %d", updateSite.BlockHTTPCode, 406)
+	if updateSite.BlockHTTPCode != 302 {
+		t.Errorf("BlockHTTPCode got %d expected %d", updateSite.BlockHTTPCode, 302)
+	}
+	if updateSite.BlockRedirectURL != "/blocked" {
+		t.Errorf("BlockRedirectURL got %s expected %s", updateSite.BlockRedirectURL, "/blocked")
 	}
 	if updateSite.BlockDurationSeconds != 86402 {
 		t.Errorf("BlockDurationSeconds got %d expected %d", updateSite.BlockDurationSeconds, 86402)


### PR DESCRIPTION
This commit adds support for performing 301 and 302 redirects to a defined url using custom response codes.

It also updates the tests for the default blocking code as it now supports changing the default from 406 to 301,302, or 400-599.