### PR TITLE
Edge service retries

### DIFF
--- a/api.go
+++ b/api.go
@@ -2978,12 +2978,12 @@ func (sc *Client) CreateOrUpdateEdgeDeploymentService(corpName, siteName, fastly
 			return errMsg(body) // Typically incorrect user info
 		case http.StatusNotFound: // 404
 			// Wait and send another request
-			sleep_time *= 2
-			time.Sleep(sleep_time)
+			sleepTime *= 2
+			time.Sleep(sleepTime)
 		default: // Something else
 			// Wait and send another request
-			sleep_time *= 2
-			time.Sleep(sleep_time)
+			sleepTime *= 2
+			time.Sleep(sleepTime)
 		}
 	}
 

--- a/api.go
+++ b/api.go
@@ -2900,7 +2900,7 @@ func (sc *Client) doRequestDetailed(method, url, reqBody string) (*http.Response
 		b = strings.NewReader(reqBody)
 	}
 
-	req, err := http.NewRequest(method, apiURL+url, b)
+	req, _ := http.NewRequest(method, apiURL+url, b)
 
 	if sc.email != "" {
 		// token auth

--- a/api.go
+++ b/api.go
@@ -2897,6 +2897,22 @@ func (sc *Client) GetSitePrimaryAgentKey(corpName, siteName string) (PrimaryAgen
 func (sc *Client) CreateOrUpdateEdgeDeployment(corpName, siteName string) error {
 	_, err := sc.doRequest("PUT", fmt.Sprintf("/v0/corps/%s/sites/%s/edgeDeployment", corpName, siteName), "")
 
+	// Only run more retries if there was an error
+	if err != nil {
+		var sleep_time = 4 * time.Second
+		for i := 0; i < 5; i++ {
+			if err != nil {
+				sleep_time *= 2
+				log.Println("Sleeping for ", sleep_time)
+				time.Sleep(sleep_time)
+				_, err = sc.doRequest("PUT", fmt.Sprintf("/v0/corps/%s/sites/%s/edgeDeployment", corpName, siteName), "")
+			}
+			if err == nil {
+				break
+			}
+		}
+	}
+
 	return err
 }
 
@@ -2927,37 +2943,21 @@ func (sc *Client) CreateOrUpdateEdgeDeploymentService(corpName, siteName, fastly
 
 	_, err = sc.doRequest("PUT", fmt.Sprintf("/v0/corps/%s/sites/%s/edgeDeployment/%s", corpName, siteName, fastlySID), string(b))
 
-	// Starting at 4 is an arbitrary decision
-	var sleep_time = 4 * time.Second
+	// Only run retries if there was an error
 	if err != nil {
-		sleep_time *= 2
-		log.Println("Sleeping for ", sleep_time)
-		time.Sleep(sleep_time)
-		_, err = sc.doRequest("PUT", fmt.Sprintf("/v0/corps/%s/sites/%s/edgeDeployment/%s", corpName, siteName, fastlySID), string(b))
-	}
-	if err != nil {
-		sleep_time *= 2
-		log.Println("Sleeping for ", sleep_time)
-		time.Sleep(sleep_time)
-		_, err = sc.doRequest("PUT", fmt.Sprintf("/v0/corps/%s/sites/%s/edgeDeployment/%s", corpName, siteName, fastlySID), string(b))
-	}
-	if err != nil {
-		sleep_time *= 2
-		log.Println("Sleeping for ", sleep_time)
-		time.Sleep(sleep_time)
-		_, err = sc.doRequest("PUT", fmt.Sprintf("/v0/corps/%s/sites/%s/edgeDeployment/%s", corpName, siteName, fastlySID), string(b))
-	}
-	if err != nil {
-		sleep_time *= 2
-		log.Println("Sleeping for ", sleep_time)
-		time.Sleep(sleep_time)
-		_, err = sc.doRequest("PUT", fmt.Sprintf("/v0/corps/%s/sites/%s/edgeDeployment/%s", corpName, siteName, fastlySID), string(b))
-	}
-	if err != nil {
-		sleep_time *= 2
-		log.Println("Sleeping for ", sleep_time)
-		time.Sleep(sleep_time)
-		_, err = sc.doRequest("PUT", fmt.Sprintf("/v0/corps/%s/sites/%s/edgeDeployment/%s", corpName, siteName, fastlySID), string(b))
+		// Starting at 4 is an arbitrary decision
+		var sleep_time = 4 * time.Second
+		for i := 0; i < 5; i++ {
+			if err != nil {
+				sleep_time *= 2
+				log.Println("Sleeping for ", sleep_time)
+				time.Sleep(sleep_time)
+				_, err = sc.doRequest("PUT", fmt.Sprintf("/v0/corps/%s/sites/%s/edgeDeployment/%s", corpName, siteName, fastlySID), string(b))
+			}
+			if err == nil {
+				break
+			}
+		}
 	}
 
 	return err

--- a/api.go
+++ b/api.go
@@ -2897,7 +2897,7 @@ func (sc *Client) doRequestDetailed(method, url, reqBody string) (*http.Response
 
 // CreateOrUpdateEdgeDeployment initializes the Next-Gen WAF deployment in Compute@Edge and configures the site for Edge Deployment.
 func (sc *Client) CreateOrUpdateEdgeDeployment(corpName, siteName string) error {
-	_, err := sc.doRequestDetailed("PUT", fmt.Sprintf("/v0/corps/%s/sites/%s/edgeDeployment", corpName, siteName), "")
+	_, err := sc.doRequest("PUT", fmt.Sprintf("/v0/corps/%s/sites/%s/edgeDeployment", corpName, siteName), "")
 
 	return err
 }

--- a/api.go
+++ b/api.go
@@ -2954,7 +2954,7 @@ func (sc *Client) CreateOrUpdateEdgeDeploymentService(corpName, siteName, fastly
 		return err
 	}
 
-	var sleep_time = 4 * time.Second
+	var sleepTime = 4 * time.Second
 	for i := 0; i < 6; i++ {
 		resp, err := sc.doRequestDetailed("PUT", fmt.Sprintf("/v0/corps/%s/sites/%s/edgeDeployment/%s", corpName, siteName, fastlySID), string(b))
 

--- a/api.go
+++ b/api.go
@@ -75,34 +75,7 @@ func (sc *Client) authenticate(email, password string) error {
 }
 
 func (sc *Client) doRequest(method, url, reqBody string) ([]byte, error) {
-	client := &http.Client{}
-
-	var b io.Reader
-	if reqBody != "" {
-		b = strings.NewReader(reqBody)
-	}
-
-	req, err := http.NewRequest(method, apiURL+url, b)
-	if err != nil {
-		return []byte{}, err
-	}
-
-	if sc.email != "" {
-		// token auth
-		req.Header.Set("X-API-User", sc.email)
-		req.Header.Set("X-API-Token", sc.token)
-	} else {
-		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", sc.token))
-	}
-
-	if sc.fastlyKey != "" {
-		req.Header.Set("Fastly-Key", sc.fastlyKey)
-	}
-
-	req.Header.Add("Content-Type", "application/json")
-	req.Header.Set("User-Agent", "go-sigsci")
-
-	resp, err := client.Do(req)
+	resp, err := sc.doRequestDetailed(method, url, reqBody)
 	if err != nil {
 		return []byte{}, err
 	}
@@ -2920,7 +2893,6 @@ func (sc *Client) doRequestDetailed(method, url, reqBody string) (*http.Response
 	resp, err := client.Do(req)
 
 	return resp, err
-
 }
 
 // CreateOrUpdateEdgeDeployment initializes the Next-Gen WAF deployment in Compute@Edge and configures the site for Edge Deployment.

--- a/api.go
+++ b/api.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"net/url"
 	"strings"
@@ -2914,6 +2915,7 @@ type CreateOrUpdateEdgeDeploymentServiceBody struct {
 // CreateOrUpdateEdgeDeploymentService copies the backends from the Fastly service to the
 // Edge Deployment and pre-configures the Fastly service with an edge dictionary and custom VCL.
 func (sc *Client) CreateOrUpdateEdgeDeploymentService(corpName, siteName, fastlySID string, body CreateOrUpdateEdgeDeploymentServiceBody) error {
+	log.Println("No sleep yet")
 	if sc.fastlyKey == "" {
 		return errors.New("please set Fastly-Key with the client.SetFastlyKey method")
 	}
@@ -2924,6 +2926,39 @@ func (sc *Client) CreateOrUpdateEdgeDeploymentService(corpName, siteName, fastly
 	}
 
 	_, err = sc.doRequest("PUT", fmt.Sprintf("/v0/corps/%s/sites/%s/edgeDeployment/%s", corpName, siteName, fastlySID), string(b))
+
+	// Starting at 4 is an arbitrary decision
+	var sleep_time = 4 * time.Second
+	if err != nil {
+		sleep_time *= 2
+		log.Println("Sleeping for ", sleep_time)
+		time.Sleep(sleep_time)
+		_, err = sc.doRequest("PUT", fmt.Sprintf("/v0/corps/%s/sites/%s/edgeDeployment/%s", corpName, siteName, fastlySID), string(b))
+	}
+	if err != nil {
+		sleep_time *= 2
+		log.Println("Sleeping for ", sleep_time)
+		time.Sleep(sleep_time)
+		_, err = sc.doRequest("PUT", fmt.Sprintf("/v0/corps/%s/sites/%s/edgeDeployment/%s", corpName, siteName, fastlySID), string(b))
+	}
+	if err != nil {
+		sleep_time *= 2
+		log.Println("Sleeping for ", sleep_time)
+		time.Sleep(sleep_time)
+		_, err = sc.doRequest("PUT", fmt.Sprintf("/v0/corps/%s/sites/%s/edgeDeployment/%s", corpName, siteName, fastlySID), string(b))
+	}
+	if err != nil {
+		sleep_time *= 2
+		log.Println("Sleeping for ", sleep_time)
+		time.Sleep(sleep_time)
+		_, err = sc.doRequest("PUT", fmt.Sprintf("/v0/corps/%s/sites/%s/edgeDeployment/%s", corpName, siteName, fastlySID), string(b))
+	}
+	if err != nil {
+		sleep_time *= 2
+		log.Println("Sleeping for ", sleep_time)
+		time.Sleep(sleep_time)
+		_, err = sc.doRequest("PUT", fmt.Sprintf("/v0/corps/%s/sites/%s/edgeDeployment/%s", corpName, siteName, fastlySID), string(b))
+	}
 
 	return err
 }


### PR DESCRIPTION
The intention of this PR is to make the function CreateOrUpdateEdgeDeploymentService() more resilient by adding a limited number of retries. This way if the edge service is not ready yet, requests will continue to be made until successful or the maximum number of statically defined number of retries is exceeded. 

The function doRequestDetailed() was also added to provide access to the entire response object, which includes the response status, headers, and body. The response status is useful to various case switches to break out of the retry logic.

I have done 2 tests which both involve attempting to create and link and NGWAF edge service to a VCL service.
```
package main

import (
	"log"
	"os"
	"time"

	sigsci "github.com/signalsciences/go-sigsci"
)

func main() {
	corp := os.Getenv("NGWAF_CORP")
	site := os.Getenv("NGWAF_SITE")
	email := os.Getenv("NGWAF_EMAIL")
	token := os.Getenv("NGWAF_TOKEN")

	fastly_sid := "" //your sid here
	fastly_api_key := os.Getenv("FASTLY_API_KEY")
	ActivateVersion := true
	PercentEnabled := 100

	const sleep_time = 2 * time.Second

	sc := sigsci.NewTokenClient(email, token)

	sc.SetFastlyKey(fastly_api_key)

	log.Println("Creating edge deployment with updated API")

	log.Println(sc.CreateOrUpdateEdgeDeployment(corp, site))

	CreateOrUpdateEdgeDeploymentServiceBody := sigsci.CreateOrUpdateEdgeDeploymentServiceBody{
		ActivateVersion: &ActivateVersion,
		PercentEnabled:  PercentEnabled,
	}
	log.Println(sc.CreateOrUpdateEdgeDeploymentService(corp, site, fastly_sid, CreateOrUpdateEdgeDeploymentServiceBody))

}

```

1. For the first test, which was designed to fail, I tried calling on a SID that did not exist by leaving fastly_sid blank. Below is that result.
```! go run main_api_update.go 
2023/06/26 12:58:59 Creating edge deployment with updated API
2023/06/26 12:59:41 <nil>
2023/06/26 13:08:07 <nil>
```
No modificaitons were made to the VCL as expected.

2. For my second test, I create a VCL service and used a valid Fastly SID in the above script. Below is that output.
```! go run main_api_update.go 
2023/06/26 13:10:15 Creating edge deployment with updated API
2023/06/26 13:11:10 <nil>
2023/06/26 13:11:39 <nil>
```
The expected modificaitons were made to the VCL with the edge inspector linked.

Please let me know if there are other tests that would provide better coverage.