### PR TITLE
Extend timeouts for linking of Edge Inspection Service to Fastly Service

### DIFF
--- a/api.go
+++ b/api.go
@@ -2967,9 +2967,7 @@ func (sc *Client) CreateOrUpdateEdgeDeploymentService(corpName, siteName, fastly
 	}
 
 	// If we got here linking of Fastly Service with Inspection Service has timed out
-	err = errors.New("timed out associating fastly service with inspection service")
-
-	return err
+	return errors.New("timed out associating fastly service with inspection service. retry later.")
 }
 
 // DetachEdgeDeploymentService removes all backends from the Edge Deployment connected to the Fastly service

--- a/api.go
+++ b/api.go
@@ -2926,7 +2926,10 @@ func (sc *Client) CreateOrUpdateEdgeDeploymentService(corpName, siteName, fastly
 		return err
 	}
 
-	var sleepTime = 15 * time.Second
+	// Call to link inspection service with the Fastly service will fail if inspection service is not available. Set sleeptime to
+	// 20 seconds for the first sleep before retrying the first time
+	var sleepTime = 20 * time.Second
+
 	for i := 0; i < 6; i++ {
 		resp, err := sc.doRequestDetailed("PUT", fmt.Sprintf("/v0/corps/%s/sites/%s/edgeDeployment/%s", corpName, siteName, fastlySID), string(b))
 
@@ -2948,6 +2951,8 @@ func (sc *Client) CreateOrUpdateEdgeDeploymentService(corpName, siteName, fastly
 			// Only sleep if Retry-After response header is available
 			if resp.Header.Get("Retry-After") != "" {
 				time.Sleep(sleepTime)
+				// Add 5 seconds to sleeptime for every consecutive retry e.g. wait 20, 25, 30, 35, 40, 45 seconds
+				sleepTime += 5 * time.Second
 			} else {
 				body, err := io.ReadAll(resp.Body)
 				if err != nil {
@@ -2960,6 +2965,9 @@ func (sc *Client) CreateOrUpdateEdgeDeploymentService(corpName, siteName, fastly
 			time.Sleep(sleepTime)
 		}
 	}
+
+	// If we got here linking of Fastly Service with Inspection Service has timed out
+	err = errors.New("timed out associating fastly service with inspection service")
 
 	return err
 }

--- a/api.go
+++ b/api.go
@@ -2967,7 +2967,7 @@ func (sc *Client) CreateOrUpdateEdgeDeploymentService(corpName, siteName, fastly
 	}
 
 	// If we got here linking of Fastly Service with Inspection Service has timed out
-	return errors.New("timed out associating fastly service with inspection service. retry later.")
+	return errors.New("timed out associating fastly service with inspection service retry later")
 }
 
 // DetachEdgeDeploymentService removes all backends from the Edge Deployment connected to the Fastly service


### PR DESCRIPTION
Linking of an inspection service with Fastly service may take more than 90 seconds. Extending timeouts. 