### PR TITLE
MEDIUM: api: add attack thresholds+immediate block

### DIFF
--- a/api.go
+++ b/api.go
@@ -2070,7 +2070,7 @@ func (sc *Client) GetTimeseries(corpName, siteName string, query url.Values) ([]
 
 // AttackThreshold
 type AttackThreshold struct {
-	Interval  int `json:"interval,omitempty"` // Interval in minutes of threshold. Valid options 1, 10, 60
+	Interval  int `json:"interval,omitempty"`  // Interval in minutes of threshold. Valid options 1, 10, 60
 	Threshold int `json:"threshold,omitempty"` // Threshold from 1 - 10000
 }
 

--- a/api.go
+++ b/api.go
@@ -2071,7 +2071,7 @@ func (sc *Client) GetTimeseries(corpName, siteName string, query url.Values) ([]
 // AttackThreshold
 type AttackThreshold struct {
 	Interval  int `json:"interval,omitempty"` // Interval in minutes of threshold. Valid options 1, 10, 60
-	Threshold int `json:threshold,omitempty"` // Threshold from 1 - 10000
+	Threshold int `json:"threshold,omitempty"` // Threshold from 1 - 10000
 }
 
 // CreateSiteBody is the structure required to create a Site.


### PR DESCRIPTION
This commit adds the new AttackThresholds and
ImmediateBlock API parameters to the Site struct.

These parameters allow you to adjust the attack
thresholds for the 1 minute, 10 minute, and 1 hour intervals.

`gofumpt` was also ran on the source, which
resulted on a number of formatting improvements.