### PR TITLE
MINOR: Add edgeDeployment confirmation request.

### DIFF
--- a/api.go
+++ b/api.go
@@ -2920,8 +2920,8 @@ type EdgeDeployment struct {
 	ServicesAttached []FastlyService `json:"ServicesAttached"`
 }
 
-// ConfirmEdgeDeployment retrieves currently deployed EdgeWafs and Fastly Services mapped to a site..
-func (sc *Client) ConfirmEdgeDeployment(corpName, siteName string) (EdgeDeployment, error) {
+// GetEdgeDeployment retrieves currently deployed EdgeWafs and Fastly Services mapped to a site..
+func (sc *Client) GetEdgeDeployment(corpName, siteName string) (EdgeDeployment, error) {
 	resp, err := sc.doRequest("GET", fmt.Sprintf("/v0/corps/%s/sites/%s/edgeDeployment", corpName, siteName), "")
 	if err != nil {
 		return EdgeDeployment{}, err

--- a/api.go
+++ b/api.go
@@ -2906,6 +2906,36 @@ func (sc *Client) doRequestDetailed(method, url, reqBody string) (*http.Response
 	return resp, err
 }
 
+// FastlyService contains details about a Fastly Service mapped a site.
+type FastlyService struct {
+	ID        string    `json:"id"`
+	AccountID string    `json:"accountID"`
+	Created   time.Time `json:"created"`
+	CreatedBy string    `json:"createdBy"`
+}
+
+// EdgeDeployment contains details about an Edge Deployment
+type EdgeDeployment struct {
+	AgentHostName    string          `json:"AgentHostName"`
+	ServicesAttached []FastlyService `json:"ServicesAttached"`
+}
+
+// ConfirmEdgeDeployment retrieves currently deployed EdgeWafs and Fastly Services mapped to a site..
+func (sc *Client) ConfirmEdgeDeployment(corpName, siteName string) (EdgeDeployment, error) {
+	resp, err := sc.doRequest("GET", fmt.Sprintf("/v0/corps/%s/sites/%s/edgeDeployment", corpName, siteName), "")
+	if err != nil {
+		return EdgeDeployment{}, err
+	}
+
+	var edgeDeployment EdgeDeployment
+	err = json.Unmarshal(resp, &edgeDeployment)
+	if err != nil {
+		return EdgeDeployment{}, err
+	}
+
+	return edgeDeployment, nil
+}
+
 // CreateOrUpdateEdgeDeployment initializes the Next-Gen WAF deployment in Compute@Edge and configures the site for Edge Deployment.
 func (sc *Client) CreateOrUpdateEdgeDeployment(corpName, siteName string) error {
 	_, err := sc.doRequest("PUT", fmt.Sprintf("/v0/corps/%s/sites/%s/edgeDeployment", corpName, siteName), "")


### PR DESCRIPTION
Adds confirmation endpoint response from:
https://docs.fastly.com/en/ngwaf/edge-deployment

Would be useful for any CLI utility or internal lib to have the ability to query this using the package (e.g "do I already have a service mapped")

Implementation:
```
	edgeDeployment, err := sc.GetEdgeDeployment("jeremy", "mysite")
	if err != nil {
		return err
	}
	fmt.Printf("%+v\n\n\n\n", edgeDeployment)

	for _, edgeWAF := range edgeDeployment.ServicesAttached {
		fmt.Println(edgeWAF.ID)
		fmt.Println(edgeWAF.CreatedBy)
		fmt.Println(edgeWAF.Created)
		fmt.Println(edgeWAF.AccountID)
	}
```

Output:
```
{AgentHostName:moop.edgecompute.app ServicesAttached:[{ID:1KpBNBo1SqpppqIIZ1GRR3 AccountID:6u7fz9eLFkR1kMF2ediYJz Created:2024-04-24 16:05:21 +0000 UTC CreatedBy:meep@fastly.com}]}


1KpBNBo1SqpppqIIZ1GRR3
meep@fastly.com
2024-04-24 16:05:21 +0000 UTC
6u7fz9eLFkR1kMF2ediYJz
```

Did not add a test because I did not see tests for related endpoints, however can add those if time allows.