### PR TITLE
MINOR: api: add new CustomClientIP option to Edge deployment

### DIFF
--- a/api.go
+++ b/api.go
@@ -2955,6 +2955,7 @@ func (sc *Client) DeleteEdgeDeployment(corpName, siteName string) error {
 type CreateOrUpdateEdgeDeploymentServiceBody struct {
 	ActivateVersion *bool `json:"activateVersion,omitempty"` // Activate Fastly VCL service after clone
 	PercentEnabled  int   `json:"percentEnabled,omitempty"`  // Percentage of traffic to send to NGWAF@Edge
+	CustomClientIP  *bool `json:"customClientIP,omitempty"`  // enable to prevent Fastly-Client-IP from being overwritten by the NGWAF@Edge
 }
 
 // CreateOrUpdateEdgeDeploymentService copies the backends from the Fastly service to the


### PR DESCRIPTION
This commit adds the new option `CustomClientIP` / `customClientIP` to the CreateOrUpdateEdgeDeploymentServiceBody struct. This option prevents the Fastly-Client-IP header from being overwritten by the NGWAF. It is intended for advanced use cases.