### PR TITLE
Handle blank AgentLastRuleUpdate

### DIFF
--- a/api.go
+++ b/api.go
@@ -1905,7 +1905,7 @@ type nullTime struct {
 	time.Time
 }
 
-// UnmarshalJSON implements custom unmarshaling for customTime.
+// UnmarshalJSON implements custom unmarshaling for nullTime.
 // Handles cases where the value is either a valid time string or an empty string.
 func (ct *nullTime) UnmarshalJSON(data []byte) error {
 	// Unmarshaling as a string

--- a/api.go
+++ b/api.go
@@ -1857,7 +1857,7 @@ type Agent struct {
 	AgentDecisionTime95th       float64   `json:"agent.decision_time_95th"`
 	AgentDecisionTime99th       float64   `json:"agent.decision_time_99th"`
 	AgentEnabled                bool      `json:"agent.enabled"`
-	AgentLastRuleUpdate         time.Time `json:"agent.last_rule_update"`
+	AgentLastRuleUpdate         nullTime  `json:"agent.last_rule_update"`
 	AgentLastSeen               time.Time `json:"agent.last_seen"`
 	AgentLatencyTime50th        float64   `json:"agent.latency_time_50th"`
 	AgentLatencyTime95th        float64   `json:"agent.latency_time_95th"`
@@ -1898,6 +1898,36 @@ type Agent struct {
 	RuntimeMemSize              int       `json:"mem_size"`
 	RuntimeNumGc                int       `json:"num_gc"`
 	RuntimeNumGoroutines        int       `json:"num_goroutines"`
+}
+
+// customTime wraps time.Time and handles empty string values during unmarshaling.
+type nullTime struct {
+	time.Time
+}
+
+// UnmarshalJSON implements custom unmarshaling for customTime.
+// Handles cases where the value is either a valid time string or an empty string.
+func (ct *nullTime) UnmarshalJSON(data []byte) error {
+	// Unmarshaling as a string
+	var str string
+	if err := json.Unmarshal(data, &str); err != nil {
+		return err
+	}
+
+	// If empty, leave the time as a zero value.
+	if str == "" {
+		*ct = nullTime{time.Time{}}
+		return nil
+	}
+
+	// Attempt to parse the time string in the expected format.
+	parsedTime, err := time.Parse(time.RFC3339, str)
+	if err != nil {
+		return err
+	}
+
+	*ct = nullTime{parsedTime}
+	return nil
 }
 
 // agentsResponse is the response for the list agents endpoint

--- a/api.go
+++ b/api.go
@@ -1857,7 +1857,7 @@ type Agent struct {
 	AgentDecisionTime95th       float64   `json:"agent.decision_time_95th"`
 	AgentDecisionTime99th       float64   `json:"agent.decision_time_99th"`
 	AgentEnabled                bool      `json:"agent.enabled"`
-	AgentLastRuleUpdate         nullTime  `json:"agent.last_rule_update"`
+	AgentLastRuleUpdate         emptyTime `json:"agent.last_rule_update"`
 	AgentLastSeen               time.Time `json:"agent.last_seen"`
 	AgentLatencyTime50th        float64   `json:"agent.latency_time_50th"`
 	AgentLatencyTime95th        float64   `json:"agent.latency_time_95th"`
@@ -1900,14 +1900,14 @@ type Agent struct {
 	RuntimeNumGoroutines        int       `json:"num_goroutines"`
 }
 
-// customTime wraps time.Time and handles empty string values during unmarshaling.
-type nullTime struct {
+// emptyTime wraps time.Time and handles empty string values during unmarshaling.
+type emptyTime struct {
 	time.Time
 }
 
-// UnmarshalJSON implements custom unmarshaling for nullTime.
+// UnmarshalJSON implements custom unmarshaling for emptyTime.
 // Handles cases where the value is either a valid time string or an empty string.
-func (ct *nullTime) UnmarshalJSON(data []byte) error {
+func (ct *emptyTime) UnmarshalJSON(data []byte) error {
 	// Unmarshaling as a string
 	var str string
 	if err := json.Unmarshal(data, &str); err != nil {
@@ -1916,7 +1916,7 @@ func (ct *nullTime) UnmarshalJSON(data []byte) error {
 
 	// If empty, leave the time as a zero value.
 	if str == "" {
-		*ct = nullTime{time.Time{}}
+		*ct = emptyTime{time.Time{}}
 		return nil
 	}
 
@@ -1926,7 +1926,7 @@ func (ct *nullTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	*ct = nullTime{parsedTime}
+	*ct = emptyTime{parsedTime}
 	return nil
 }
 


### PR DESCRIPTION
Ran into some issues today running a debug util that uses `ListAgents` failed each time when the site contained an EdgeWAF.  This is because the agents endpoint is returning:

```
      "agent.last_rule_update": "",
```

In the JSON response, which we try to unmarshal via:
```
AgentLastRuleUpdate         time.Time  `json:"agent.last_rule_update"`
```

Which results in:
```
2024/09/04 19:17:12 parsing time "" as "2006-01-02T15:04:05Z07:00": cannot parse "" as "2006"
```

Could probably handle this from the API, but easier to just implement a custom `Unmarshal()` to handle the empty "" value in this scenario. I don't believe any other keys need to be changed, as `AgentLastSeen` is always updated.

```
	agents, err := sc.ListAgents("xxxx", "xxxxx")
	if err != nil {
		log.Fatal(err)
	}

	for _, agent := range agents {
		fmt.Println(agent.AgentName)
		fmt.Println(agent.AgentLastRuleUpdate)
	}
```

Now returns:
```
Site ID:  xxxxx
EdgeSecurity
0001-01-01 00:00:00 +0000 UTC
waf-lab-demo-cf9fcf48-gd6zt
2024-09-04 10:58:05 +0000 UTC
```