### PR TITLE
don't omit on empty for 0 percent

### DIFF
--- a/api.go
+++ b/api.go
@@ -2956,7 +2956,7 @@ func (sc *Client) DeleteEdgeDeployment(corpName, siteName string) error {
 
 type CreateOrUpdateEdgeDeploymentServiceBody struct {
 	ActivateVersion *bool `json:"activateVersion,omitempty"` // Activate Fastly VCL service after clone
-	PercentEnabled  int   `json:"percentEnabled,omitempty"`  // Percentage of traffic to send to NGWAF@Edge
+	PercentEnabled  int   `json:"percentEnabled"`            // Percentage of traffic to send to NGWAF@Edge
 	CustomClientIP  *bool `json:"customClientIP,omitempty"`  // enable to prevent Fastly-Client-IP from being overwritten by the NGWAF@Edge
 }
 

--- a/api.go
+++ b/api.go
@@ -2956,7 +2956,7 @@ func (sc *Client) DeleteEdgeDeployment(corpName, siteName string) error {
 
 type CreateOrUpdateEdgeDeploymentServiceBody struct {
 	ActivateVersion *bool `json:"activateVersion,omitempty"` // Activate Fastly VCL service after clone
-	PercentEnabled  int   `json:"percentEnabled"`            // Percentage of traffic to send to NGWAF@Edge
+	PercentEnabled  *int  `json:"percentEnabled,omitempty"`  // Percentage of traffic to send to NGWAF@Edge
 	CustomClientIP  *bool `json:"customClientIP,omitempty"`  // enable to prevent Fastly-Client-IP from being overwritten by the NGWAF@Edge
 }
 


### PR DESCRIPTION
The fix is to remove the omit empty tag so a value of percent_enabled = 0 does not get dropped by the API.