### PR TITLE
add support for simulator api

### DIFF
--- a/api.go
+++ b/api.go
@@ -3040,14 +3040,14 @@ func (sc *Client) UpdateEdgeDeploymentBackends(corpName, siteName, fastlySID str
 	return err
 }
 
-// Simulation request the sample request and response for the simulation test
-type SimulationBody struct {
+// Simulator request the sample request and response for the simulator test
+type SimulatorBody struct {
 	SampleRequest  string `json:"sample_request"`
 	SampleResponse string `json:"sample_response"`
 }
 
-// SimulationResponse the response of the simulation test
-type ResponseSimulationBody struct {
+// SimulatorResponse the response of the simulator test
+type ResponseSimulatorBody struct {
 	Data struct {
 		WafResponse  int `json:"waf_response"`
 		ResponseCode int `json:"response_code"`
@@ -3063,25 +3063,25 @@ type ResponseSimulationBody struct {
 	} `json:"data"`
 }
 
-// getSimulationOutput gets the simulation output
-func getResponseSimulationBody(response []byte) (ResponseSimulationBody, error) {
-	var responseSimulation ResponseSimulationBody
-	err := json.Unmarshal(response, &responseSimulation)
+// getSimulatorOutput gets the simulator output
+func getResponseSimulatorBody(response []byte) (ResponseSimulatorBody, error) {
+	var responseSimulator ResponseSimulatorBody
+	err := json.Unmarshal(response, &responseSimulator)
 	if err != nil {
-		return ResponseSimulationBody{}, err
+		return ResponseSimulatorBody{}, err
 	}
-	return responseSimulation, nil
+	return responseSimulator, nil
 }
 
-// SendSimulation sends a simulation test to
-func (sc *Client) SendSimulation(corpName, siteName string, body SimulationBody) (ResponseSimulationBody, error) {
+// SendSimulator sends a simulator test to
+func (sc *Client) SendSimulator(corpName, siteName string, body SimulatorBody) (ResponseSimulatorBody, error) {
 	b, err := json.Marshal(body)
 	if err != nil {
-		return ResponseSimulationBody{}, err
+		return ResponseSimulatorBody{}, err
 	}
 	resp, err := sc.doRequest("POST", fmt.Sprintf("/v0/corps/%s/sites/%s/simulator", corpName, siteName), string(b))
 	if err != nil {
-		return ResponseSimulationBody{}, err
+		return ResponseSimulatorBody{}, err
 	}
-	return getResponseSimulationBody(resp)
+	return getResponseSimulatorBody(resp)
 }

--- a/api.go
+++ b/api.go
@@ -3063,7 +3063,7 @@ type ResponseSimulationBody struct {
 	} `json:"data"`
 }
 
-// getSimulationOutput gets the simulation output
+// getResponseSimulationBody gets the simulation response
 func getResponseSimulationBody(response []byte) (ResponseSimulationBody, error) {
 	var responseSimulation ResponseSimulationBody
 	err := json.Unmarshal(response, &responseSimulation)
@@ -3073,7 +3073,7 @@ func getResponseSimulationBody(response []byte) (ResponseSimulationBody, error) 
 	return responseSimulation, nil
 }
 
-// SendSimulation sends a simulation test to
+// SendSimulation sends a simulation test and returns the response
 func (sc *Client) SendSimulation(corpName, siteName string, body SimulationBody) (ResponseSimulationBody, error) {
 	b, err := json.Marshal(body)
 	if err != nil {

--- a/api.go
+++ b/api.go
@@ -3039,3 +3039,49 @@ func (sc *Client) UpdateEdgeDeploymentBackends(corpName, siteName, fastlySID str
 
 	return err
 }
+
+// Simulation request the sample request and response for the simulation test
+type SimulationBody struct {
+	SampleRequest  string `json:"sample_request"`
+	SampleResponse string `json:"sample_response"`
+}
+
+// SimulationResponse the response of the simulation test
+type ResponseSimulationBody struct {
+	Data struct {
+		WafResponse  int `json:"waf_response"`
+		ResponseCode int `json:"response_code"`
+		ResponseSize int `json:"response_size"`
+		Signals      []struct {
+			Type      string `json:"type"`
+			Location  string `json:"location"`
+			Name      string `json:"name"`
+			Value     string `json:"value"`
+			Detector  string `json:"detector"`
+			Redaction int    `json:"redaction"`
+		} `json:"signals"`
+	} `json:"data"`
+}
+
+// getSimulationOutput gets the simulation output
+func getResponseSimulationBody(response []byte) (ResponseSimulationBody, error) {
+	var responseSimulation ResponseSimulationBody
+	err := json.Unmarshal(response, &responseSimulation)
+	if err != nil {
+		return ResponseSimulationBody{}, err
+	}
+	return responseSimulation, nil
+}
+
+// SendSimulation sends a simulation test to
+func (sc *Client) SendSimulation(corpName, siteName string, body SimulationBody) (ResponseSimulationBody, error) {
+	b, err := json.Marshal(body)
+	if err != nil {
+		return ResponseSimulationBody{}, err
+	}
+	resp, err := sc.doRequest("POST", fmt.Sprintf("/v0/corps/%s/sites/%s/simulator", corpName, siteName), string(b))
+	if err != nil {
+		return ResponseSimulationBody{}, err
+	}
+	return getResponseSimulationBody(resp)
+}

--- a/api.go
+++ b/api.go
@@ -3040,14 +3040,14 @@ func (sc *Client) UpdateEdgeDeploymentBackends(corpName, siteName, fastlySID str
 	return err
 }
 
-// Simulator request the sample request and response for the simulator test
-type SimulatorBody struct {
+// Simulation request the sample request and response for the simulation test
+type SimulationBody struct {
 	SampleRequest  string `json:"sample_request"`
 	SampleResponse string `json:"sample_response"`
 }
 
-// SimulatorResponse the response of the simulator test
-type ResponseSimulatorBody struct {
+// SimulationResponse the response of the simulation test
+type ResponseSimulationBody struct {
 	Data struct {
 		WafResponse  int `json:"waf_response"`
 		ResponseCode int `json:"response_code"`
@@ -3063,25 +3063,25 @@ type ResponseSimulatorBody struct {
 	} `json:"data"`
 }
 
-// getSimulatorOutput gets the simulator output
-func getResponseSimulatorBody(response []byte) (ResponseSimulatorBody, error) {
-	var responseSimulator ResponseSimulatorBody
-	err := json.Unmarshal(response, &responseSimulator)
+// getSimulationOutput gets the simulation output
+func getResponseSimulationBody(response []byte) (ResponseSimulationBody, error) {
+	var responseSimulation ResponseSimulationBody
+	err := json.Unmarshal(response, &responseSimulation)
 	if err != nil {
-		return ResponseSimulatorBody{}, err
+		return ResponseSimulationBody{}, err
 	}
-	return responseSimulator, nil
+	return responseSimulation, nil
 }
 
-// SendSimulator sends a simulator test to
-func (sc *Client) SendSimulator(corpName, siteName string, body SimulatorBody) (ResponseSimulatorBody, error) {
+// SendSimulation sends a simulation test to
+func (sc *Client) SendSimulation(corpName, siteName string, body SimulationBody) (ResponseSimulationBody, error) {
 	b, err := json.Marshal(body)
 	if err != nil {
-		return ResponseSimulatorBody{}, err
+		return ResponseSimulationBody{}, err
 	}
 	resp, err := sc.doRequest("POST", fmt.Sprintf("/v0/corps/%s/sites/%s/simulator", corpName, siteName), string(b))
 	if err != nil {
-		return ResponseSimulatorBody{}, err
+		return ResponseSimulationBody{}, err
 	}
-	return getResponseSimulatorBody(resp)
+	return getResponseSimulationBody(resp)
 }

--- a/api_test.go
+++ b/api_test.go
@@ -1887,22 +1887,22 @@ func TestCRUDSiteRequestRule(t *testing.T) {
 	}
 }
 
-func TestSendSimulator(t *testing.T) {
+func TestSendSimulation(t *testing.T) {
 	sc := NewTokenClient(testcreds.email, testcreds.token)
 	corp := testcreds.corp
 	site := testcreds.site
-	body := SimulatorBody{
+	body := SimulationBody{
 		// sample request with xss paylaod
 		SampleRequest:  `POST /?q=<script>alert(1)</script> HTTP/1.1\nHost: sample.foo\n\n`,
 		SampleResponse: `HTTP/1.1 200 OK`,
 	}
-	responseSimulator, err := sc.SendSimulator(corp, site, body)
+	responseSimulation, err := sc.SendSimulation(corp, site, body)
 	if err != nil {
 		t.Fatal(err)
 	}
 	// check for XSS signal
 	found := false
-	for _, signal := range responseSimulator.Data.Signals {
+	for _, signal := range responseSimulation.Data.Signals {
 		if signal.Type == "XSS" {
 			found = true
 		}

--- a/api_test.go
+++ b/api_test.go
@@ -1887,22 +1887,22 @@ func TestCRUDSiteRequestRule(t *testing.T) {
 	}
 }
 
-func TestSendSimulation(t *testing.T) {
+func TestSendSimulator(t *testing.T) {
 	sc := NewTokenClient(testcreds.email, testcreds.token)
 	corp := testcreds.corp
 	site := testcreds.site
-	body := SimulationBody{
+	body := SimulatorBody{
 		// sample request with xss paylaod
 		SampleRequest:  `POST /?q=<script>alert(1)</script> HTTP/1.1\nHost: sample.foo\n\n`,
 		SampleResponse: `HTTP/1.1 200 OK`,
 	}
-	responseSimulation, err := sc.SendSimulation(corp, site, body)
+	responseSimulator, err := sc.SendSimulator(corp, site, body)
 	if err != nil {
 		t.Fatal(err)
 	}
 	// check for XSS signal
 	found := false
-	for _, signal := range responseSimulation.Data.Signals {
+	for _, signal := range responseSimulator.Data.Signals {
 		if signal.Type == "XSS" {
 			found = true
 		}


### PR DESCRIPTION
This PR add support for the [WAF simulator API](https://docs.fastly.com/signalsciences/api/#_corps__corpName__sites__siteName__simulator_post)