### PR TITLE
Refactor create or update edge deployment

### DIFF
--- a/api.go
+++ b/api.go
@@ -2924,19 +2924,14 @@ type EdgeDeployment struct {
 	ServicesAttached []FastlyService `json:"ServicesAttached"`
 }
 
-// EdgeDeploymentRequest defines the structure of the optional request body for creating an EdgeDeployment.
-type EdgeDeploymentCreate struct {
-	AuthorizedServices []string `json:"authorizedServices,omitempty"`
+type CreateOrUpdateEdgeDeploymentBody struct {
+	AuthorizedServices *[]string `json:"authorizedServices,omitempty"`
 }
 
-// CreateOrUpdateEdgeDeployment initializes the Next-Gen WAF and configures the site for Edge Deployment.
-// Takes in optional authorizedServices body to allow authorization of compute@edge services.
-func (sc *Client) CreateOrUpdateEdgeDeployment(corpName, siteName string, authorizedServices []string) error {
-	reqBody := EdgeDeploymentCreate{
-		AuthorizedServices: authorizedServices,
-	}
-
-	b, err := json.Marshal(reqBody)
+// CreateOrUpdateEdgeDeployment initializes the Next-Gen WAF deployment and configures the site for Edge Deployment.
+// Optional: facilitates `authorizedServices` as input to authorize a compute@edge instance.
+func (sc *Client) CreateOrUpdateEdgeDeployment(corpName, siteName string, body CreateOrUpdateEdgeDeploymentBody) error {
+	b, err := json.Marshal(body)
 	if err != nil {
 		return err
 	}

--- a/api.go
+++ b/api.go
@@ -2945,26 +2945,6 @@ func (sc *Client) CreateOrUpdateEdgeDeployment(corpName, siteName string, author
 	return err
 }
 
-// CreateOrUpdateEdgeDeployment initializes the Next-Gen WAF and configures the site for Edge Deployment, with optional authorizedServices payload to authorize
-// compute@edge services for inspection.
-func (sc *Client) CreateOrUpdateEdgeDeployment(corpName, siteName string, authorizedServices []string) error {
-	var reqBody string
-
-	// Construct `
-	if len(authorizedServices) > 0 {
-		b, err := json.Marshal(map[string]interface{}{
-			"authorizedServices": authorizedServices,
-		})
-		if err != nil {
-			return err
-		}
-		reqBody = string(b)
-	}
-
-	_, err := sc.doRequest("PUT", fmt.Sprintf("/v0/corps/%s/sites/%s/edgeDeployment", corpName, siteName), reqBody)
-	return err
-}
-
 // DeleteEdgeDeployment deletes an edge deployment
 func (sc *Client) DeleteEdgeDeployment(corpName, siteName string) error {
 	_, err := sc.doRequest("DELETE", fmt.Sprintf("/v0/corps/%s/sites/%s/edgeDeployment", corpName, siteName), "")


### PR DESCRIPTION
- Refactors #69 to be more inline with the rest of the codebase :
- Structs for payload handling and adds extensibility. 
- Handles nil payload by marshaling json struct with `omitempty`
- Fixes duplicative err return. 