### PR TITLE
BUG/MEDIUM: api: exclude DELETE calls from content-type check

### DIFF
--- a/api.go
+++ b/api.go
@@ -98,7 +98,7 @@ func (sc *Client) doRequest(method, url, reqBody string) ([]byte, error) {
 	// Handle unexpected HTML responses, truncate at 300 characters to avoid stdout bombing.
 	var maxHTMLLength = 300
 	contentType := resp.Header.Get("Content-Type")
-	if !strings.Contains(contentType, "application/json") {
+	if method != "DELETE" && !strings.Contains(contentType, "application/json") {
 		truncatedBody := string(body)
 		if strings.Contains(contentType, "text/html") && len(truncatedBody) > maxHTMLLength {
 			truncatedBody = truncatedBody[:maxHTMLLength] + "...[truncated]"


### PR DESCRIPTION
In 816bbfd98b (add content-type and redirect handling) some content-type handling was added to validate that we were receiving a proper JSON response back. However, in the case of DELETE calls there is an empty content-type returned.

This causes erroneous errors such as the following:

```
│ Error: received unexpected content-type () response:
```

This commit excludes DELETE calls from the content-type validation.