### PR TITLE
fix(CorpUser): Struct is now incorrect based on API responses

### DIFF
--- a/api.go
+++ b/api.go
@@ -252,7 +252,7 @@ const (
 type CorpUser struct {
 	Name        string
 	Email       string
-	Memberships map[string]string
+	Memberships map[string]interface{}
 	Role        string
 	Status      string
 	MFAEnabled  bool


### PR DESCRIPTION
The API now appears to return a `data: []` response with the link to the membership list, which is not of the type `map[string]string`. While investigating implementing a related issue https://github.com/signalsciences/terraform-provider-sigsci/issues/242 I was receiving errors  unmarshaling such as:

```
│ Error: error inviting corp user: json: cannot unmarshal array into Go struct field CorpUser.Memberships of type string  
```

Looking into the response I can see that the response structure must have changed:
```
$ curl -s -H "x-api-user:XXX" -H "x-api-token:XXX" -H "Content-Type: application/json" https://dashboard.signalsciences.net/api/v0/corps/XXX/users/XXXX@XXXX.com | jq .memberships                                                                                                                                                                                                                                                                                     
{
  "data": [],
  "uri": "/api/v0/corps/XXXX/users/XXXX@XXX.com/memberships"
}
```