### PR TITLE
BUG/MINOR: api: ignore content-type check for http/204

### DIFF
--- a/api.go
+++ b/api.go
@@ -98,7 +98,7 @@ func (sc *Client) doRequest(method, url, reqBody string) ([]byte, error) {
 	// Handle unexpected HTML responses, truncate at 300 characters to avoid stdout bombing.
 	var maxHTMLLength = 300
 	contentType := resp.Header.Get("Content-Type")
-	if method != "DELETE" && !strings.Contains(contentType, "application/json") {
+	if resp.StatusCode != 204 && !strings.Contains(contentType, "application/json") {
 		truncatedBody := string(body)
 		if strings.Contains(contentType, "text/html") && len(truncatedBody) > maxHTMLLength {
 			truncatedBody = truncatedBody[:maxHTMLLength] + "...[truncated]"


### PR DESCRIPTION
In 9cbaa52 (BUG/MEDIUM: api: exclude DELETE calls from content-type check) logic was added to disregard checking if the content-type is application/json for the DELETE method. While this fix did address the issue at hand it was not as extensive as it should have been.

It was recently reported that PATCH methods are also having an issue. Instead of adding each individual method it is better for us to check if the HTTP status code is 204 (No Content) as the API is returning this when it is not expecting to return any content.

This commit swaps the method check with one on the response code 204 and should fix this issue broadly against all methods.