### PR TITLE
DOC: fix comments to note new 100k rl/threshold limit

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
 
     - name: Set up Go 1.20
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v6
       with:
         go-version: '1.20.x'
       id: go

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ jobs:
       id: go
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
 
     - name: Lint
       run: make lint
@@ -26,6 +26,6 @@ jobs:
         GOBIN=$PWD/bin make lint
 
     - name: Staticcheck
-      uses: dominikh/staticcheck-action@v1.3.0
+      uses: dominikh/staticcheck-action@v1.4.0
       with:
-        version: "2023.1"
+        version: "latest"

--- a/api.go
+++ b/api.go
@@ -2095,7 +2095,7 @@ func (sc *Client) GetTimeseries(corpName, siteName string, query url.Values) ([]
 // AttackThreshold
 type AttackThreshold struct {
 	Interval  int `json:"interval,omitempty"`  // Interval in minutes of threshold. Valid options 1, 10, 60
-	Threshold int `json:"threshold,omitempty"` // Threshold from 1 - 10000
+	Threshold int `json:"threshold,omitempty"` // Threshold from 1 - 100000
 }
 
 // CreateSiteBody is the structure required to create a Site.
@@ -2805,7 +2805,7 @@ type DetectionUpdateBody struct {
 type AlertUpdateBody struct {
 	LongName             string `json:"longName"`
 	Interval             int    `json:"interval"`  // 1, 10 or 60
-	Threshold            int    `json:"threshold"` // greater than 0, max 10000
+	Threshold            int    `json:"threshold"` // greater than 0, max 100000
 	SkipNotifications    bool   `json:"skipNotifications,omitempty"`
 	Enabled              bool   `json:"enabled"`
 	Action               string `json:"action"`


### PR DESCRIPTION
The API has increased site alert/rate limit threshold from 10k maximum to 100k.

This updates the code comments to reflect that.